### PR TITLE
FIX-#36: Serialization caches.

### DIFF
--- a/docs/flow/unidist/core/backends/mpi/core/serialization.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/serialization.rst
@@ -8,19 +8,21 @@
 Serialization API
 """""""""""""""""
 
-Class :py:class:`~unidist.core.backends.mpi.core.serialization.ComplexSerializer` supports data serialization of complex types
-with lambdas, functions, member functions. Moreover, the class support out-of-band data serialization
+Class :py:class:`~unidist.core.backends.mpi.core.serialization.ComplexDataSerializer` supports data serialization of complex types
+with lambdas, functions, member functions and large data arrays. In particular, the class supports out-of-band data serialization
 for a set of pickle 5 protocol compatible libraries - pandas and NumPy, specifically ``pandas.DataFrame``, ``pandas.Series`` and ``np.ndarray`` types.
-Class :py:class:`~unidist.core.backends.mpi.core.serialization.SimpleSerializer` supports data serialization of simple data types, including
-lambdas, functions, member functions, but with no performance optimization for raw data.
+Use this class in case serialization of compound objects with different unknown types, poissibly large arrays.
+Class :py:class:`~unidist.core.backends.mpi.core.serialization.SimpleDataSerializer` supports data serialization of simple data types.
+Also, the class has an API for lambdas, functions, member functions serialization (and uses cloudpickle library for that purpose),
+but with no performance optimization for large raw data.  Use this class when you know exact object type for serialization and it`s not cosists of large datasets.
 
 API
 ===
 
-.. autoclass:: unidist.core.backends.mpi.core.serialization.ComplexSerializer
+.. autoclass:: unidist.core.backends.mpi.core.serialization.ComplexDataSerializer
    :private-members:
    :members:
 
-.. autoclass:: unidist.core.backends.mpi.core.serialization.SimpleSerializer
+.. autoclass:: unidist.core.backends.mpi.core.serialization.SimpleDataSerializer
    :private-members:
    :members:

--- a/docs/flow/unidist/core/backends/mpi/core/serialization.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/serialization.rst
@@ -11,10 +11,10 @@ Serialization API
 Class :py:class:`~unidist.core.backends.mpi.core.serialization.ComplexDataSerializer` supports data serialization of complex types
 with lambdas, functions, member functions and large data arrays. In particular, the class supports out-of-band data serialization
 for a set of pickle 5 protocol compatible libraries - pandas and NumPy, specifically ``pandas.DataFrame``, ``pandas.Series`` and ``np.ndarray`` types.
-Use this class in case serialization of compound objects with different unknown types, poissibly large arrays.
+This class is used in case of serialization of compound objects with different unknown types, possibly large arrays.
 Class :py:class:`~unidist.core.backends.mpi.core.serialization.SimpleDataSerializer` supports data serialization of simple data types.
-Also, the class has an API for lambdas, functions, member functions serialization (and uses cloudpickle library for that purpose),
-but with no performance optimization for large raw data.  Use this class when you know exact object type for serialization and it`s not cosists of large datasets.
+Also, the class has an API for serialization of lambdas, functions, member functions (and uses ``cloudpickle`` library for that purpose),
+but with no performance optimization for large raw data. This class is used when exact object type is known for serialization and it doesn't consist of large datasets.
 
 API
 ===

--- a/docs/flow/unidist/core/backends/mpi/core/serialization.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/serialization.rst
@@ -8,13 +8,19 @@
 Serialization API
 """""""""""""""""
 
-Class :py:class:`~unidist.core.backends.mpi.core.serialization.MPISerializer` supports data serialization of complex types
+Class :py:class:`~unidist.core.backends.mpi.core.serialization.ComplexSerializer` supports data serialization of complex types
 with lambdas, functions, member functions. Moreover, the class support out-of-band data serialization
 for a set of pickle 5 protocol compatible libraries - pandas and NumPy, specifically ``pandas.DataFrame``, ``pandas.Series`` and ``np.ndarray`` types.
+Class :py:class:`~unidist.core.backends.mpi.core.serialization.SimpleSerializer` supports data serialization of simple data types, including
+lambdas, functions, member functions, but with no performance optimization for raw data.
 
 API
 ===
 
-.. autoclass:: unidist.core.backends.mpi.core.serialization.MPISerializer
+.. autoclass:: unidist.core.backends.mpi.core.serialization.ComplexSerializer
+   :private-members:
+   :members:
+
+.. autoclass:: unidist.core.backends.mpi.core.serialization.SimpleSerializer
    :private-members:
    :members:

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -5,6 +5,7 @@
 """Common classes and utilities."""
 
 import logging
+import sys
 
 from unidist.core.backends.common.data_id import DataID, is_data_id
 
@@ -126,6 +127,23 @@ def get_logger(logger_name, file_name, activate=False):
     logger.addHandler(f_handler)
 
     return logger
+
+
+def get_size(data):
+    """
+    Calculate the size of an object in bytes.
+
+    Parameters
+    ----------
+    data : object
+        Python object.
+
+    Returns
+    -------
+    int
+        Size of an object in bytes.
+    """
+    return sys.getsizeof(data)
 
 
 def unwrapped_data_ids_list(args):

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -5,7 +5,6 @@
 """Common classes and utilities."""
 
 import logging
-import sys
 
 from unidist.core.backends.common.data_id import DataID, is_data_id
 
@@ -127,23 +126,6 @@ def get_logger(logger_name, file_name, activate=False):
     logger.addHandler(f_handler)
 
     return logger
-
-
-def get_size(data):
-    """
-    Calculate the size of an object in bytes.
-
-    Parameters
-    ----------
-    data : object
-        Python object.
-
-    Returns
-    -------
-    int
-        Size of an object in bytes.
-    """
-    return sys.getsizeof(data)
 
 
 def unwrapped_data_ids_list(args):

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -13,11 +13,16 @@ except ImportError:
         "Missing dependency 'mpi4py'. Use pip or conda to install it."
     ) from None
 
+import unidist.core.backends.mpi.core.common as common
+
+from unidist.core.backends.mpi.core.serialization import (
+    ComplexSerializer,
+    SimpleSerializer,
+)  # noqa: E402
+
 # TODO: Find a way to move this after all imports
 mpi4py.rc(recv_mprobe=False)
 from mpi4py import MPI  # noqa: E402
-
-from unidist.core.backends.mpi.core.serialization import MPISerializer  # noqa: E402
 
 
 # Sleep time setting inside the busy wait loop
@@ -90,7 +95,7 @@ def mpi_isend_object(comm, data, dest_rank):
     return comm.isend(data, dest=dest_rank)
 
 
-def mpi_send_buffer(comm, data, dest_rank):
+def mpi_send_buffer(comm, data_size, data, dest_rank):
     """
     Send buffer object to another MPI rank in a blocking way.
 
@@ -103,7 +108,30 @@ def mpi_send_buffer(comm, data, dest_rank):
     dest_rank : int
         Target MPI process to transfer data.
     """
+    comm.send(data_size, dest=dest_rank)
     comm.Send([data, MPI.CHAR], dest=dest_rank)
+
+
+def mpi_recv_buffer(comm, source_rank):
+    """
+    Receive buffer data.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    source_rank : int
+        Communication event source rank
+
+    Returns
+    -------
+    object
+        Buffer array or serialized object.
+    """
+    buf_size = comm.recv(source=source_rank)
+    s_buffer = bytearray(buf_size)
+    comm.Recv([s_buffer, MPI.CHAR], source=source_rank)
+    return s_buffer
 
 
 def mpi_isend_buffer(comm, data, dest_rank):
@@ -179,6 +207,29 @@ def recv_operation_type(comm):
 # ---------------------------------
 
 
+def send_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank):
+    """
+    Send already serialized complex data.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    data : object
+        Data object to send.
+    dest_rank : int
+        Target MPI process to transfer data.
+    """
+    # Send message pack bytestring
+    mpi_send_buffer(comm, len(s_data), s_data, dest_rank)
+    # Send the necessary metadata
+    mpi_send_object(comm, len(raw_buffers), dest_rank)
+    for i in range(0, len(raw_buffers)):
+        mpi_send_buffer(comm, len(raw_buffers[i].raw()), raw_buffers[i], dest_rank)
+    # TODO: do not send if raw_buffers is zero
+    mpi_send_object(comm, len_buffers, dest_rank)
+
+
 def send_complex_data(comm, data, dest_rank):
     """
     Send the data that consists of different user provided complex types, lambdas and buffers.
@@ -191,24 +242,74 @@ def send_complex_data(comm, data, dest_rank):
         Data object to send.
     dest_rank : int
         Target MPI process to transfer data.
+
+    Returns
+    -------
+    object
+        A serialized msgpack data.
+    list
+        A list of pickle buffers.
+    list
+        A list of buffers amount for each object.
     """
-    serializer = MPISerializer()
+    serializer = ComplexSerializer()
     # Main job
     s_data = serializer.serialize(data)
-
-    # Send message pack bytestring
-    comm.send(len(s_data), dest=dest_rank)
-    comm.Send([s_data, MPI.CHAR], dest=dest_rank)
     # Retrive the metadata
     raw_buffers = serializer.buffers
     len_buffers = serializer.len_buffers
 
+    # MPI comminucation
+    send_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank)
+
+    # For caching purpose
+    return s_data, raw_buffers, len_buffers
+
+
+def isend_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank):
+    """
+    Send serialized complex data.
+
+    Non-blocking asynchronous interface.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    s_data: object
+        A serialized msgpack data.
+    raw_buffers : list
+        A list of pickle buffers.
+    len_buffers : list
+        A list of buffers amount for each object.
+    dest_rank : int
+        Target MPI process to transfer data.
+
+    Returns
+    -------
+    list
+        A list of pairs, ``MPI_Isend`` handler and associated data to send.
+    """
+    handler_list = []
+
+    # Send message pack bytestring
+    h1 = mpi_isend_object(comm, len(s_data), dest_rank)
+    h2 = mpi_isend_buffer(comm, s_data, dest_rank)
+    handler_list.append((h1, None))
+    handler_list.append((h2, s_data))
+
     # Send the necessary metadata
-    comm.send(len(raw_buffers), dest=dest_rank)
+    h3 = mpi_isend_object(comm, len(raw_buffers), dest_rank)
+    handler_list.append((h3, None))
     for i in range(0, len(raw_buffers)):
-        comm.send(len(raw_buffers[i].raw()), dest=dest_rank)
-        comm.Send([raw_buffers[i], MPI.CHAR], dest=dest_rank)
-    comm.send(len_buffers, dest=dest_rank)
+        h4 = mpi_isend_object(comm, len(raw_buffers[i].raw()), dest_rank)
+        h5 = mpi_isend_buffer(comm, raw_buffers[i], dest_rank)
+        handler_list.append((h4, None))
+        handler_list.append((h5, raw_buffers[i]))
+    h6 = mpi_isend_object(comm, len_buffers, dest_rank)
+    handler_list.append((h6, len_buffers))
+
+    return handler_list
 
 
 def isend_complex_data(comm, data, dest_rank):
@@ -230,34 +331,27 @@ def isend_complex_data(comm, data, dest_rank):
     -------
     list
         A list of pairs, ``MPI_Isend`` handler and associated data to send.
+    object
+        A serialized msgpack data.
+    list
+        A list of pickle buffers.
+    list
+        A list of buffers amount for each object.
     """
     handler_list = []
 
-    serializer = MPISerializer()
+    serializer = ComplexSerializer()
     # Main job
     s_data = serializer.serialize(data)
-
-    # Send message pack bytestring
-    h1 = mpi_isend_object(comm, len(s_data), dest_rank)
-    h2 = mpi_isend_buffer(comm, s_data, dest_rank)
-    handler_list.append((h1, None))
-    handler_list.append((h2, s_data))
     # Retrive the metadata
     raw_buffers = serializer.buffers
     len_buffers = serializer.len_buffers
 
-    # Send the necessary metadata
-    h3 = mpi_isend_object(comm, len(raw_buffers), dest_rank)
-    handler_list.append((h3, None))
-    for i in range(0, len(raw_buffers)):
-        h4 = mpi_isend_object(comm, len(raw_buffers[i].raw()), dest_rank)
-        h5 = mpi_isend_buffer(comm, raw_buffers[i], dest_rank)
-        handler_list.append((h4, None))
-        handler_list.append((h5, raw_buffers[i]))
-    h6 = mpi_isend_object(comm, len_buffers, dest_rank)
-    handler_list.append((h6, len_buffers))
+    # Send message pack bytestring
+    h_list = isend_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank)
+    handler_list.extend(h_list)
 
-    return handler_list
+    return handler_list, s_data, raw_buffers, len_buffers
 
 
 def recv_complex_data(comm, source_rank):
@@ -298,7 +392,7 @@ def recv_complex_data(comm, source_rank):
     len_buffers = comm.recv(source=source_rank)
 
     # Set the necessary metadata for unpacking
-    deserializer = MPISerializer(raw_buffers, len_buffers)
+    deserializer = ComplexSerializer(raw_buffers, len_buffers)
 
     # Start unpacking
     return deserializer.deserialize(msgpack_buffer)
@@ -312,7 +406,7 @@ def send_complex_operation(comm, operation_type, operation_data, dest_rank):
     """
     Send operation and data that consist of different user provided complex types, lambdas and buffers.
 
-    The data is serialized with ``unidist.core.backends.mpi.core.MPISerializer``.
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
 
     Parameters
     ----------
@@ -329,59 +423,6 @@ def send_complex_operation(comm, operation_type, operation_data, dest_rank):
     comm.send(operation_type, dest=dest_rank)
     # Send complex dictionary data
     send_complex_data(comm, operation_data, dest_rank)
-
-
-def isend_complex_operation(comm, operation_type, operation_data, dest_rank):
-    """
-    Send operation and data that consists of different user provided complex types, lambdas and buffers.
-
-    Non-blocking asynchronous interface. The data is serialized with ``unidist.core.backends.mpi.core.MPISerializer``.
-
-    Parameters
-    ----------
-    comm : object
-        MPI communicator object.
-    operation_type : ``unidist.core.backends.mpi.core.common.Operation``
-        Operation message type.
-    operation_data : object
-        Data object to send.
-    dest_rank : int
-        Target MPI process to transfer data.
-
-    Returns
-    -------
-    list
-        A list of pairs, ``MPI_Isend`` handler and associated data to send.
-    """
-    handler_list = []
-    # Send operation type
-    h1 = mpi_isend_object(comm, operation_type, dest_rank)
-    handler_list.append((h1, None))
-    # Send complex dictionary data
-    h2_list = isend_complex_data(comm, operation_data, dest_rank)
-    handler_list.extend(h2_list)
-    return handler_list
-
-
-def recv_complex_operation(comm, source_rank):
-    """
-    Receive the data that may consist of different user provided complex types, lambdas and buffers.
-
-    The data is de-serialized from received buffer.
-
-    Parameters
-    ----------
-    comm : object
-        MPI communicator object.
-    source_rank : int
-        Source MPI process to receive data from.
-
-    Returns
-    -------
-    object
-        Received data object from another MPI process.
-    """
-    return recv_complex_data(comm, source_rank)
 
 
 def send_simple_operation(comm, operation_type, operation_data, dest_rank):
@@ -430,3 +471,243 @@ def recv_simple_operation(comm, source_rank):
     De-serialization is a simple pickle.load in this case
     """
     return comm.recv(source=source_rank)
+
+
+def send_operation_data(comm, operation_data, dest_rank, is_serialized=False):
+    """
+    Send data that consist of different user provided complex types, lambdas and buffers.
+
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
+    Function works with already serialized data.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    operation_data : object
+        Data object to send.
+    dest_rank : int
+        Target MPI process to transfer data.
+    is_serialized : bool
+        `operation_data` is already serialized or not.
+
+    Returns
+    -------
+    dict or None
+        Serialization data for caching purpose.
+    """
+    if is_serialized:
+        # Send already serialized data
+        s_data = operation_data["s_data"]
+        raw_buffers = operation_data["raw_buffers"]
+        len_buffers = operation_data["len_buffers"]
+        send_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank)
+        return None
+    else:
+        # Serialize and send the data
+        s_data, raw_buffers, len_buffers = send_complex_data(
+            comm, operation_data, dest_rank
+        )
+        return {
+            "s_data": s_data,
+            "raw_buffers": raw_buffers,
+            "len_buffers": len_buffers,
+        }
+
+
+def send_operation(
+    comm, operation_type, operation_data, dest_rank, is_serialized=False
+):
+    """
+    Send operation and data that consist of different user provided complex types, lambdas and buffers.
+
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
+    Function works with already serialized data.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    operation_type : ``unidist.core.backends.mpi.core.common.Operation``
+        Operation message type.
+    operation_data : object
+        Data object to send.
+    dest_rank : int
+        Target MPI process to transfer data.
+    is_serialized : bool
+        `operation_data` is already serialized or not.
+
+    Returns
+    -------
+    dict or None
+        Serialization data for caching purpose.
+    """
+    # Send operation type
+    mpi_send_object(comm, operation_type, dest_rank)
+    # Send operation data
+    return send_operation_data(comm, operation_data, dest_rank, is_serialized)
+
+
+def isend_complex_operation(
+    comm, operation_type, operation_data, dest_rank, is_serialized=False
+):
+    """
+    Send operation and data that consist of different user provided complex types, lambdas and buffers.
+
+    Non-blocking asynchronous interface.
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
+    Function works with already serialized data.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    operation_type : ``unidist.core.backends.mpi.core.common.Operation``
+        Operation message type.
+    operation_data : object
+        Data object to send.
+    dest_rank : int
+        Target MPI process to transfer data.
+    is_serialized : bool
+        `operation_data` is already serialized or not.
+
+    Returns
+    -------
+    dict or None
+        Serialization data for caching purpose.
+    """
+    # Send operation type
+    handler_list = []
+    h1 = mpi_isend_object(comm, operation_type, dest_rank)
+    handler_list.append((h1, None))
+
+    # Send operation data
+    if is_serialized:
+        # Send already serialized data
+        s_data = operation_data["s_data"]
+        raw_buffers = operation_data["raw_buffers"]
+        len_buffers = operation_data["len_buffers"]
+
+        h2_list = isend_complex_data_impl(
+            comm, s_data, raw_buffers, len_buffers, dest_rank
+        )
+        handler_list.extend(h2_list)
+
+        return handler_list, None
+    else:
+        # Serialize and send the data
+        h2_list, s_data, raw_buffers, len_buffers = isend_complex_data(
+            comm, operation_data, dest_rank
+        )
+        handler_list.extend(h2_list)
+        return handler_list, {
+            "s_data": s_data,
+            "raw_buffers": raw_buffers,
+            "len_buffers": len_buffers,
+        }
+
+
+def send_remote_task_operation(comm, operation_type, operation_data, dest_rank):
+    """
+    Send operation and data that consist of different user provided complex types, lambdas and buffers.
+
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``
+    or ``unidist.core.backends.mpi.core.SimpleSerializer`` depending on the data size.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    operation_type : ``unidist.core.backends.mpi.core.common.Operation``
+        Operation message type.
+    operation_data : object
+        Data object to send.
+    dest_rank : int
+        Target MPI process to transfer data.
+    """
+    # Send operation type
+    mpi_send_object(comm, operation_type, dest_rank)
+
+    # Check the message size and decide on serialization scheme
+    if common.get_size(operation_data) < 256 * 1024:
+        # Send the data type for serialization (simple or complex)
+        mpi_send_object(comm, True, dest_rank)
+        # Serialize and send the simple data
+        s_operation_data = SimpleSerializer().serialize(operation_data)
+        mpi_send_buffer(comm, len(s_operation_data), s_operation_data, dest_rank)
+    else:
+        mpi_send_object(comm, False, dest_rank)
+        # Serialize and send the complex data
+        send_complex_data(comm, operation_data, dest_rank)
+
+
+def recv_remote_task_data(comm, source_rank):
+    """
+    Receive the data for remote operation.
+
+    The data is de-serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``
+    or ``unidist.core.backends.mpi.core.SimpleSerializer`` depending on the data size.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    source_rank : int
+        Source MPI process to receive data from.
+
+    Returns
+    -------
+    object
+        Received data object from another MPI process.
+    """
+    # Decide what deserialization scheme to use
+    # TODO: check busy wait
+    is_simple = comm.recv(source=source_rank)
+    if is_simple:
+        s_buffer = mpi_recv_buffer(comm, source_rank)
+        return SimpleSerializer().deserialize(s_buffer)
+    else:
+        return recv_complex_data(comm, source_rank)
+
+
+def send_serialized_operation(comm, operation_type, operation_data, dest_rank):
+    """
+    Send operation and serialized simple data.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    operation_type : unidist.core.backends.mpi.core.common.Operation
+        Operation message type.
+    operation_data : object
+        Data object to send.
+    dest_rank : int
+        Target MPI process to transfer data.
+    """
+    # Send operation type
+    mpi_send_object(comm, operation_type, dest_rank)
+    # Send request details
+    mpi_send_buffer(comm, len(operation_data), operation_data, dest_rank)
+
+
+def recv_serialized_data(comm, source_rank):
+    """
+    Receive serialized data buffer.
+
+    The data is de-serialized with ``unidist.core.backends.mpi.core.SimpleSerializer``.
+
+    Parameters
+    ----------
+    comm : object
+        MPI communicator object.
+    source_rank : int
+        Source MPI process to receive data from.
+
+    Returns
+    -------
+    object
+        Received de-serialized data object from another MPI process.
+    """
+    s_buffer = mpi_recv_buffer(comm, source_rank)
+    return SimpleSerializer().deserialize_pickle(s_buffer)

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -501,6 +501,11 @@ def send_operation_data(comm, operation_data, dest_rank, is_serialized=False):
     -------
     dict or None
         Serialization data for caching purpose or nothing.
+
+    Notes
+    -----
+    Function returns ``None`` if `operation_data` is already serialized,
+    and the ``dict`` in case the data was serialized and packed in a dictionary.
     """
     if is_serialized:
         # Send already serialized data
@@ -547,6 +552,11 @@ def send_operation(
     -------
     dict or None
         Serialization data for caching purpose.
+
+    Notes
+    -----
+    Function returns ``None`` if `operation_data` is already serialized,
+    and the ``dict`` in case the data was serialized and packed in a dictionary.
     """
     # Send operation type
     mpi_send_object(comm, operation_type, dest_rank)
@@ -581,6 +591,12 @@ def isend_complex_operation(
     -------
     dict and dict or dict and None
         Async handlers and serialization data for caching purpose.
+
+    Notes
+    -----
+    Function always returns a ``dict`` containing async handlers to the sent MPI operations.
+    In additions, function returns ``None`` if `operation_data` is already serialized,
+    and the ``dict`` in case the data was serialized and packed in a dictionary.
     """
     # Send operation type
     handlers = []

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -14,8 +14,8 @@ except ImportError:
     ) from None
 
 from unidist.core.backends.mpi.core.serialization import (
-    ComplexSerializer,
-    SimpleSerializer,
+    ComplexDataSerializer,
+    SimpleDataSerializer,
 )
 
 # TODO: Find a way to move this after all imports
@@ -256,7 +256,7 @@ def send_complex_data(comm, data, dest_rank):
     list
         A list of buffers amount for each object.
     """
-    serializer = ComplexSerializer()
+    serializer = ComplexDataSerializer()
     # Main job
     s_data = serializer.serialize(data)
     # Retrive the metadata
@@ -345,7 +345,7 @@ def _isend_complex_data(comm, data, dest_rank):
     """
     handlers = []
 
-    serializer = ComplexSerializer()
+    serializer = ComplexDataSerializer()
     # Main job
     s_data = serializer.serialize(data)
     # Retrive the metadata
@@ -398,7 +398,7 @@ def recv_complex_data(comm, source_rank):
     len_buffers = comm.recv(source=source_rank)
 
     # Set the necessary metadata for unpacking
-    deserializer = ComplexSerializer(raw_buffers, len_buffers)
+    deserializer = ComplexDataSerializer(raw_buffers, len_buffers)
 
     # Start unpacking
     return deserializer.deserialize(msgpack_buffer)
@@ -412,7 +412,7 @@ def send_complex_operation(comm, operation_type, operation_data, dest_rank):
     """
     Send operation and data that consist of different user provided complex types, lambdas and buffers.
 
-    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexDataSerializer``.
 
     Parameters
     ----------
@@ -483,7 +483,7 @@ def send_operation_data(comm, operation_data, dest_rank, is_serialized=False):
     """
     Send data that consist of different user provided complex types, lambdas and buffers.
 
-    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexDataSerializer``.
     Function works with already serialized data.
 
     Parameters
@@ -500,7 +500,7 @@ def send_operation_data(comm, operation_data, dest_rank, is_serialized=False):
     Returns
     -------
     dict or None
-        Serialization data for caching purpose.
+        Serialization data for caching purpose or nothing.
     """
     if is_serialized:
         # Send already serialized data
@@ -527,7 +527,7 @@ def send_operation(
     """
     Send operation and data that consist of different user provided complex types, lambdas and buffers.
 
-    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexDataSerializer``.
     Function works with already serialized data.
 
     Parameters
@@ -561,7 +561,7 @@ def isend_complex_operation(
     Send operation and data that consist of different user provided complex types, lambdas and buffers.
 
     Non-blocking asynchronous interface.
-    The data is serialized with ``unidist.core.backends.mpi.core.ComplexSerializer``.
+    The data is serialized with ``unidist.core.backends.mpi.core.ComplexDataSerializer``.
     Function works with already serialized data.
 
     Parameters
@@ -580,7 +580,7 @@ def isend_complex_operation(
     Returns
     -------
     dict and dict or dict and None
-        Serialization data for caching purpose.
+        Async handlers and serialization data for caching purpose.
     """
     # Send operation type
     handlers = []
@@ -659,7 +659,7 @@ def recv_serialized_data(comm, source_rank):
     """
     Receive serialized data buffer.
 
-    The data is de-serialized with ``unidist.core.backends.mpi.core.SimpleSerializer``.
+    The data is de-serialized with ``unidist.core.backends.mpi.core.SimpleDataSerializer``.
 
     Parameters
     ----------
@@ -674,4 +674,4 @@ def recv_serialized_data(comm, source_rank):
         Received de-serialized data object from another MPI process.
     """
     s_buffer = mpi_recv_buffer(comm, source_rank)
-    return SimpleSerializer().deserialize_pickle(s_buffer)
+    return SimpleDataSerializer().deserialize_pickle(s_buffer)

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -101,12 +101,12 @@ def mpi_send_buffer(comm, data_size, data, dest_rank):
     ----------
     comm : object
         MPI communicator object.
-    data_size : buffer size
-        Buffer object size in bytes.
-    data : object
+    buffer_size : int
+        Buffer size in bytes.
+    buffer : object
         Buffer object to send.
     dest_rank : int
-        Target MPI process to transfer data.
+        Target MPI process to transfer buffer.
     """
     comm.send(data_size, dest=dest_rank)
     comm.Send([data, MPI.CHAR], dest=dest_rank)
@@ -114,7 +114,7 @@ def mpi_send_buffer(comm, data_size, data, dest_rank):
 
 def mpi_recv_buffer(comm, source_rank):
     """
-    Receive buffer data.
+    Receive data buffer.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ def mpi_recv_buffer(comm, source_rank):
     Returns
     -------
     object
-        Buffer array or serialized object.
+        Array buffer or serialized object.
     """
     buf_size = comm.recv(source=source_rank)
     s_buffer = bytearray(buf_size)
@@ -215,7 +215,7 @@ def _send_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank):
     ----------
     comm : object
         MPI communicator object.
-    s_data : object
+    s_data : bytearray
         Serialized data as bytearray.
     raw_buffers : list
         Pickle buffers list, out-of-band data collected with pickle 5 protocol.
@@ -280,7 +280,7 @@ def _isend_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank):
     ----------
     comm : object
         MPI communicator object.
-    s_data: object
+    s_data : object
         A serialized msgpack data.
     raw_buffers : list
         A list of pickle buffers.
@@ -433,7 +433,7 @@ def send_complex_operation(comm, operation_type, operation_data, dest_rank):
 
 def send_simple_operation(comm, operation_type, operation_data, dest_rank):
     """
-    Send operation and Python standard data types.
+    Send an operation and standard Python data types.
 
     Parameters
     ----------
@@ -579,7 +579,7 @@ def isend_complex_operation(
 
     Returns
     -------
-    dict or None
+    dict and dict or dict and None
         Serialization data for caching purpose.
     """
     # Send operation type

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -93,7 +93,7 @@ def mpi_isend_object(comm, data, dest_rank):
     return comm.isend(data, dest=dest_rank)
 
 
-def mpi_send_buffer(comm, data_size, data, dest_rank):
+def mpi_send_buffer(comm, buffer_size, buffer, dest_rank):
     """
     Send buffer object to another MPI rank in a blocking way.
 
@@ -108,8 +108,8 @@ def mpi_send_buffer(comm, data_size, data, dest_rank):
     dest_rank : int
         Target MPI process to transfer buffer.
     """
-    comm.send(data_size, dest=dest_rank)
-    comm.Send([data, MPI.CHAR], dest=dest_rank)
+    comm.send(buffer_size, dest=dest_rank)
+    comm.Send([buffer, MPI.CHAR], dest=dest_rank)
 
 
 def mpi_recv_buffer(comm, source_rank):
@@ -481,7 +481,7 @@ def recv_simple_operation(comm, source_rank):
 
 def send_operation_data(comm, operation_data, dest_rank, is_serialized=False):
     """
-    Send data that consist of different user provided complex types, lambdas and buffers.
+    Send data that consists of different user provided complex types, lambdas and buffers.
 
     The data is serialized with ``unidist.core.backends.mpi.core.ComplexDataSerializer``.
     Function works with already serialized data.
@@ -525,7 +525,7 @@ def send_operation(
     comm, operation_type, operation_data, dest_rank, is_serialized=False
 ):
     """
-    Send operation and data that consist of different user provided complex types, lambdas and buffers.
+    Send operation and data that consists of different user provided complex types, lambdas and buffers.
 
     The data is serialized with ``unidist.core.backends.mpi.core.ComplexDataSerializer``.
     Function works with already serialized data.
@@ -558,7 +558,7 @@ def isend_complex_operation(
     comm, operation_type, operation_data, dest_rank, is_serialized=False
 ):
     """
-    Send operation and data that consist of different user provided complex types, lambdas and buffers.
+    Send operation and data that consists of different user provided complex types, lambdas and buffers.
 
     Non-blocking asynchronous interface.
     The data is serialized with ``unidist.core.backends.mpi.core.ComplexDataSerializer``.

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -353,7 +353,9 @@ def _isend_complex_data(comm, data, dest_rank):
     len_buffers = serializer.len_buffers
 
     # Send message pack bytestring
-    handlers.extend(_isend_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank))
+    handlers.extend(
+        _isend_complex_data_impl(comm, s_data, raw_buffers, len_buffers, dest_rank)
+    )
 
     return handlers, s_data, raw_buffers, len_buffers
 

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -504,7 +504,7 @@ def send_operation_data(comm, operation_data, dest_rank, is_serialized=False):
 
     Notes
     -----
-    ``None`` is returned if `operation_data` is already serialized,
+    Function returns ``None`` if `operation_data` is already serialized,
     otherwise ``dict`` containing data serialized in this function.
     """
     if is_serialized:
@@ -556,7 +556,7 @@ def send_operation(
     Notes
     -----
     Function returns ``None`` if `operation_data` is already serialized,
-    and the ``dict`` in case the data was serialized and packed in a dictionary.
+    otherwise ``dict`` containing data serialized in this function.
     """
     # Send operation type
     mpi_send_object(comm, operation_type, dest_rank)
@@ -595,8 +595,8 @@ def isend_complex_operation(
     Notes
     -----
     Function always returns a ``dict`` containing async handlers to the sent MPI operations.
-    In additions, function returns ``None`` if `operation_data` is already serialized,
-    and the ``dict`` in case the data was serialized and packed in a dictionary.
+    In addition, ``None`` is returned if `operation_data` is already serialized,
+    otherwise ``dict`` containing data serialized in this function.
     """
     # Send operation type
     handlers = []

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -504,8 +504,8 @@ def send_operation_data(comm, operation_data, dest_rank, is_serialized=False):
 
     Notes
     -----
-    Function returns ``None`` if `operation_data` is already serialized,
-    and the ``dict`` in case the data was serialized and packed in a dictionary.
+    ``None`` is returned if `operation_data` is already serialized,
+    otherwise ``dict`` containing data serialized in this function.
     """
     if is_serialized:
         # Send already serialized data

--- a/unidist/core/backends/mpi/core/executor.py
+++ b/unidist/core/backends/mpi/core/executor.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 import unidist.core.backends.mpi.core.common as common
 import unidist.core.backends.mpi.core.communication as communication
 
-from unidist.core.backends.mpi.core.serialization import SimpleSerializer
+from unidist.core.backends.mpi.core.serialization import SimpleDataSerializer
 from unidist.core.backends.common.data_id import is_data_id
 
 # MPI stuff
@@ -306,7 +306,7 @@ class GarbageCollector:
 
     def _send_cleanup_request(self, cleanup_list):
         """
-        Send a list of deleted IDs for each worker to cleanup local storages.
+        Send a list of data IDs to be deleted for each worker to cleanup local storages.
 
         Parameters
         ----------
@@ -319,7 +319,7 @@ class GarbageCollector:
             )
         )
         # Cache serialized list of data IDs
-        s_cleanup_list = SimpleSerializer().serialize_pickle(cleanup_list)
+        s_cleanup_list = SimpleDataSerializer().serialize_pickle(cleanup_list)
         for rank_id in range(2, world_size):
             communication.send_serialized_operation(
                 comm, common.Operation.CLEANUP, s_cleanup_list, rank_id
@@ -480,7 +480,7 @@ def push_local_data(dest_rank, data_id):
             serialized_data = communication.send_operation(
                 comm, operation_type, operation_data, dest_rank, False
             )
-            object_store.cache_serialization_info(data_id, serialized_data)
+            object_store.cache_serialized_data(data_id, serialized_data)
         #  Remember pushed id
         object_store.cache_send_info(data_id, dest_rank)
 

--- a/unidist/core/backends/mpi/core/executor.py
+++ b/unidist/core/backends/mpi/core/executor.py
@@ -230,32 +230,32 @@ class ObjectStore:
             rank in self._sent_data_map[data_id]
         )
 
-    def cache_serialization_info(self, data_id, data):
+    def cache_serialized_data(self, data_id, data):
         """
         Save communication event for this `data_id` and `data`.
 
         Parameters
         ----------
         data_id : unidist.core.backends.mpi.core.common.MasterDataID
-            An ``ID`` to data.
+            An ID to data.
         data : object
-            Serialization information to cache.
+            Serialized data to cache.
         """
         self._serialization_cache[data_id] = data
 
     def is_already_serialized(self, data_id):
         """
-        Check if communication data on this `data_id` is already serialized.
+        Check if the data on this `data_id` is already serialized.
 
         Parameters
         ----------
         data_id : unidist.core.backends.common.data_id.DataID
-            An ``ID`` to data.
+            An ID to data.
 
         Returns
         -------
         bool
-            ``True`` if communication data already serialized.
+            ``True`` if the data is already serialized.
         """
         return data_id in self._serialization_cache
 
@@ -266,7 +266,7 @@ class ObjectStore:
         Parameters
         ----------
         data_id : unidist.core.backends.common.data_id.DataID
-            An ``ID`` to data.
+            An ID to data.
 
         Returns
         -------
@@ -473,7 +473,7 @@ def push_local_data(dest_rank, data_id):
         if object_store.is_already_serialized(data_id):
             operation_data = object_store.get_serialized_data(data_id)
             communication.send_operation(
-                comm, operation_type, operation_data, dest_rank, True
+                comm, operation_type, operation_data, dest_rank, is_serialized=True
             )
         else:
             operation_data = {"id": data_id, "data": object_store.get(data_id)}

--- a/unidist/core/backends/mpi/core/executor.py
+++ b/unidist/core/backends/mpi/core/executor.py
@@ -238,8 +238,8 @@ class ObjectStore:
         ----------
         data_id : unidist.core.backends.mpi.core.common.MasterDataID
             An ``ID`` to data.
-        rank : int
-            Rank number where the data was sent.
+        data : object
+            Serialization information to cache.
         """
         self._serialization_cache[data_id] = data
 
@@ -249,6 +249,11 @@ class ObjectStore:
 
         Parameters
         ----------
+        data_id : unidist.core.backends.common.data_id.DataID
+            An ``ID`` to data.
+
+        Returns
+        -------
         bool
             ``True`` if communication data already serialized.
         """
@@ -257,6 +262,16 @@ class ObjectStore:
     def get_serialized_data(self, data_id):
         """
         Get serialized data on this `data_id`.
+
+        Parameters
+        ----------
+        data_id : unidist.core.backends.common.data_id.DataID
+            An ``ID`` to data.
+
+        Returns
+        -------
+        object
+            Cached serialized data associated with `data_id`.
         """
         return self._serialization_cache[data_id]
 
@@ -446,7 +461,7 @@ def push_local_data(dest_rank, data_id):
     ----------
     dest_rank : int
         Target rank.
-    value : unidist.core.backends.mpi.core.common.MasterDataID
+    data_id : unidist.core.backends.mpi.core.common.MasterDataID
         An ID to data.
     """
     # Check if data was already pushed

--- a/unidist/core/backends/mpi/core/executor.py
+++ b/unidist/core/backends/mpi/core/executor.py
@@ -379,7 +379,7 @@ class GarbageCollector:
                     )
 
                     e_logger.debug(
-                        "Local task count {} vs global task count {}".format(
+                        "Submitted task count {} vs executed task count {}".format(
                             self._task_counter, executed_task_counter
                         )
                     )
@@ -471,14 +471,14 @@ def push_local_data(dest_rank, data_id):
         # Push the local master data to the target worker directly
         operation_type = common.Operation.PUT_DATA
         if object_store.is_already_serialized(data_id):
-            operation_data = object_store.get_serialized_data(data_id)
+            serialized_data = object_store.get_serialized_data(data_id)
             communication.send_operation(
-                comm, operation_type, operation_data, dest_rank, is_serialized=True
+                comm, operation_type, serialized_data, dest_rank, is_serialized=True
             )
         else:
             operation_data = {"id": data_id, "data": object_store.get(data_id)}
             serialized_data = communication.send_operation(
-                comm, operation_type, operation_data, dest_rank, False
+                comm, operation_type, operation_data, dest_rank, is_serialized=False
             )
             object_store.cache_serialized_data(data_id, serialized_data)
         #  Remember pushed id

--- a/unidist/core/backends/mpi/core/executor.py
+++ b/unidist/core/backends/mpi/core/executor.py
@@ -232,7 +232,7 @@ class ObjectStore:
 
     def cache_serialization_info(self, data_id, data):
         """
-        Save communication event for this `data_id` and rank.
+        Save communication event for this `data_id` and `data`.
 
         Parameters
         ----------

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -233,14 +233,14 @@ class ComplexSerializer:
 
 class SimpleSerializer:
     """
-    Class for simple data serialization/de-serialization for MPI comminication.
+    Class for simple data serialization/de-serialization for MPI communication.
 
     Notes
     -----
-    Uses cloudpickle and pickle libraries as a separate APIs.
+    Uses cloudpickle and pickle libraries as separate APIs.
     """
 
-    def serialize(self, data):
+    def serialize_cloudpickle(self, data):
         """
         Encode with a cloudpickle library.
 
@@ -272,13 +272,13 @@ class SimpleSerializer:
         """
         return pkl.dumps(data)
 
-    def deserialize(self, data):
+    def deserialize_cloudpickle(self, data):
         """
         De-serialization with cloudpickle library.
 
         Parameters
         ----------
-        obj : object
+        obj : bytearray
             Python object.
         """
         return cpkl.loads(data)
@@ -289,7 +289,7 @@ class SimpleSerializer:
 
         Parameters
         ----------
-        obj : object
+        obj : bytearray
             Python object.
         """
         return pkl.loads(data)

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -280,6 +280,11 @@ class SimpleDataSerializer:
         ----------
         obj : bytearray
             Python object.
+
+        Returns
+        -------
+        object
+            Original reconstructed object.
         """
         return cpkl.loads(data)
 
@@ -291,5 +296,10 @@ class SimpleDataSerializer:
         ----------
         obj : bytearray
             Python object.
+
+        Returns
+        -------
+        object
+            Original reconstructed object.
         """
         return pkl.loads(data)

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -22,6 +22,7 @@ import cloudpickle as cpkl
 import msgpack
 import gc  # msgpack optimization
 
+
 # Pickle 5 protocol compatible types check
 compatible_modules = ("pandas", "numpy")
 available_modules = []

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -113,8 +113,8 @@ class ComplexSerializer:
 
         Parameters
         ----------
-        frame : object
-            Pickle 5 serializable object (ex. pandas data frame).
+        data : object
+            Pickle 5 serializable object (e.g. pandas DataFrame or NumPy array).
 
         Returns
         -------

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -238,7 +238,7 @@ class SimpleSerializer:
 
     Notes
     -----
-    Uses cloudpickle and pickle libraries as a separate APIs
+    Uses cloudpickle and pickle libraries as a separate APIs.
     """
 
     def serialize(self, data):

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -72,7 +72,7 @@ def is_pickle5_serializable(data):
     return is_serializable
 
 
-class ComplexSerializer:
+class ComplexDataSerializer:
     """
     Class for data serialization/de-serialization for MPI comminication.
 
@@ -231,7 +231,7 @@ class ComplexSerializer:
         return unpacked_data
 
 
-class SimpleSerializer:
+class SimpleDataSerializer:
     """
     Class for simple data serialization/de-serialization for MPI communication.
 

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -22,7 +22,6 @@ import cloudpickle as cpkl
 import msgpack
 import gc  # msgpack optimization
 
-
 # Pickle 5 protocol compatible types check
 compatible_modules = ("pandas", "numpy")
 available_modules = []

--- a/unidist/core/backends/mpi/core/worker.py
+++ b/unidist/core/backends/mpi/core/worker.py
@@ -148,7 +148,7 @@ class ObjectStore:
 
     def cache_serialized_data(self, data_id, data):
         """
-        Save communication event for this `data_id` and rank.
+        Save serialized object for this `data_id` and rank.
 
         Parameters
         ----------
@@ -496,14 +496,22 @@ def process_get_request(source_rank, data_id):
                 operation_data = object_store.get_serialized_data(data_id)
                 # Async send to avoid possible dead-lock between workers
                 h_list, _ = communication.isend_complex_operation(
-                    comm, operation_type, operation_data, source_rank, is_serialized=True
+                    comm,
+                    operation_type,
+                    operation_data,
+                    source_rank,
+                    is_serialized=True,
                 )
                 async_operations.extend(h_list)
             else:
                 operation_data = {"id": data_id, "data": object_store.get(data_id)}
                 # Async send to avoid possible dead-lock between workers
                 h_list, serialized_data = communication.isend_complex_operation(
-                    comm, operation_type, operation_data, source_rank, is_serialized=False
+                    comm,
+                    operation_type,
+                    operation_data,
+                    source_rank,
+                    is_serialized=False,
                 )
                 async_operations.extend(h_list)
                 object_store.cache_serialized_data(data_id, serialized_data)

--- a/unidist/core/backends/mpi/core/worker.py
+++ b/unidist/core/backends/mpi/core/worker.py
@@ -152,10 +152,10 @@ class ObjectStore:
 
         Parameters
         ----------
-        data_id : unidist.core.backends.mpi.core.common.MasterDataID
+        data_id : unidist.core.backends.common.data_id.DataID
             An ``ID`` to data.
-        rank : int
-            Rank number where the data was sent.
+        data : object
+            Serialization information to cache.
         """
         self._serialization_cache[data_id] = data
 
@@ -165,6 +165,11 @@ class ObjectStore:
 
         Parameters
         ----------
+        data_id : unidist.core.backends.common.data_id.DataID
+            An ``ID`` to data.
+
+        Returns
+        -------
         bool
             ``True`` if communication data already serialized.
         """
@@ -173,6 +178,16 @@ class ObjectStore:
     def get_serialized_data(self, data_id):
         """
         Get serialized data on this `data_id`.
+
+        Parameters
+        ----------
+        data_id : unidist.core.backends.common.data_id.DataID
+            An ``ID`` to data.
+
+        Returns
+        -------
+        object
+            Cached serialized data associated with `data_id`.
         """
         return self._serialization_cache[data_id]
 

--- a/unidist/core/backends/mpi/core/worker.py
+++ b/unidist/core/backends/mpi/core/worker.py
@@ -146,32 +146,32 @@ class ObjectStore:
             if data_id in self._serialization_cache:
                 del self._serialization_cache[data_id]
 
-    def cache_serialization_info(self, data_id, data):
+    def cache_serialized_data(self, data_id, data):
         """
         Save communication event for this `data_id` and rank.
 
         Parameters
         ----------
         data_id : unidist.core.backends.common.data_id.DataID
-            An ``ID`` to data.
+            An ID to data.
         data : object
-            Serialization information to cache.
+            Serialized data to cache.
         """
         self._serialization_cache[data_id] = data
 
     def is_already_serialized(self, data_id):
         """
-        Check if communication data on this `data_id` is already serialized.
+        Check if the data on this `data_id` is already serialized.
 
         Parameters
         ----------
         data_id : unidist.core.backends.common.data_id.DataID
-            An ``ID`` to data.
+            An ID to data.
 
         Returns
         -------
         bool
-            ``True`` if communication data already serialized.
+            ``True`` if the data is already serialized.
         """
         return data_id in self._serialization_cache
 
@@ -182,7 +182,7 @@ class ObjectStore:
         Parameters
         ----------
         data_id : unidist.core.backends.common.data_id.DataID
-            An ``ID`` to data.
+            An ID to data.
 
         Returns
         -------

--- a/unidist/core/backends/mpi/core/worker.py
+++ b/unidist/core/backends/mpi/core/worker.py
@@ -496,14 +496,14 @@ def process_get_request(source_rank, data_id):
                 operation_data = object_store.get_serialized_data(data_id)
                 # Async send to avoid possible dead-lock between workers
                 h_list, _ = communication.isend_complex_operation(
-                    comm, operation_type, operation_data, source_rank, True
+                    comm, operation_type, operation_data, source_rank, is_serialized=True
                 )
                 async_operations.extend(h_list)
             else:
                 operation_data = {"id": data_id, "data": object_store.get(data_id)}
                 # Async send to avoid possible dead-lock between workers
                 h_list, serialized_data = communication.isend_complex_operation(
-                    comm, operation_type, operation_data, source_rank, False
+                    comm, operation_type, operation_data, source_rank, is_serialized=False
                 )
                 async_operations.extend(h_list)
                 object_store.cache_serialized_data(data_id, serialized_data)

--- a/unidist/core/backends/mpi/core/worker.py
+++ b/unidist/core/backends/mpi/core/worker.py
@@ -506,7 +506,7 @@ def process_get_request(source_rank, data_id):
                     comm, operation_type, operation_data, source_rank, False
                 )
                 async_operations.extend(h_list)
-                object_store.cache_serialization_info(data_id, serialized_data)
+                object_store.cache_serialized_data(data_id, serialized_data)
 
         w_logger.debug(
             "Send requested {} id to {} rank - PROCESSED".format(

--- a/unidist/core/backends/mpi/core/worker.py
+++ b/unidist/core/backends/mpi/core/worker.py
@@ -696,7 +696,7 @@ def event_loop():
 
         # Proceed the request
         if operation_type == common.Operation.EXECUTE:
-            request = communication.recv_remote_task_data(comm, source_rank)
+            request = communication.recv_complex_data(comm, source_rank)
 
             # Execute the task if possible
             pending_request = process_task_request(request)
@@ -711,7 +711,6 @@ def event_loop():
             process_get_request(request["source"], request["id"])
 
         elif operation_type == common.Operation.PUT_DATA:
-            #  request = communication.recv_complex_operation(comm, source_rank)
             request = communication.recv_complex_data(comm, source_rank)
             w_logger.debug(
                 "PUT (RECV) {} id from {} rank".format(request["id"]._id, source_rank)


### PR DESCRIPTION
## Performance numbers

**plasticc:**
|          | I_MPI 112 previous | I_MPI 112 | MPICH 112 |
|----------|--------------------|-----------|-----------|
| read_csv |             187,14 |  185.85539  |           |
| t_etl    |             735,44 | 380.46509  |           |

**ny_taxi**:
|          | I_MPI 112 previous | I_MPI 112 | MPICH 112 |
|----------|--------------------|-----------|-----------|
| read_csv | 289,68             | 238.94134 |           |
| Q1       | 1,84               | 1.09677   |           |
| Q2       | 52,93              | 50.96434  |           |
| Q3       | 12,20              | 4.78096   |           |
| Q4       | 7,33               | 5.09975   |           |

**census**:
|          | I_MPI 112 previous | I_MPI 112 | MPICH 112 |
|----------|--------------------|-----------|-----------|
| read_csv | 7,73               | 6.54384   |           |
| t_etl    | 103,75             | 81.01938  |           |
