### PR TITLE
FEAT-#62: Add `ValueSource` enum to check source of value in `Parameter`

### DIFF
--- a/unidist/config/__init__.py
+++ b/unidist/config/__init__.py
@@ -13,6 +13,7 @@ from .backends.ray import (
     RayObjectStoreMemory,
 )
 from .backends.dask import DaskMemoryLimit, IsDaskCluster, DaskSchedulerAddress
+from .parameter import ValueSource
 
 __all__ = [
     "Backend",
@@ -25,4 +26,5 @@ __all__ = [
     "DaskMemoryLimit",
     "IsDaskCluster",
     "DaskSchedulerAddress",
+    "ValueSource",
 ]


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #62  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
