### PR TITLE
FIX-#71: Fix for detecting reduce_ex for numpy structures and other built-ins

### DIFF
--- a/docs/flow/unidist/core/backends/mpi/core/serialization.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/serialization.rst
@@ -10,7 +10,7 @@ Serialization API
 
 Class :py:class:`~unidist.core.backends.mpi.core.serialization.MPISerializer` supports data serialization of complex types
 with lambdas, functions, member functions. Moreover, the class support out-of-band data serialization
-for a set of pickle 5 protocol compatible libraries - *pandas* and *numpy*.
+for a set of pickle 5 protocol compatible libraries - *pandas* and *numpy*, specifically *pandas.DataFrame* and *np.ndarray* types.
 
 API
 ===

--- a/docs/flow/unidist/core/backends/mpi/core/serialization.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/serialization.rst
@@ -10,7 +10,7 @@ Serialization API
 
 Class :py:class:`~unidist.core.backends.mpi.core.serialization.MPISerializer` supports data serialization of complex types
 with lambdas, functions, member functions. Moreover, the class support out-of-band data serialization
-for a set of pickle 5 protocol compatible libraries - *pandas* and *numpy*, specifically *pandas.DataFrame* and *np.ndarray* types.
+for a set of pickle 5 protocol compatible libraries - pandas and NumPy, specifically ``pandas.DataFrame``, ``pandas.Series`` and ``np.ndarray`` types.
 
 API
 ===

--- a/docs/flow/unidist/core/backends/mpi/core/serialization.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/serialization.rst
@@ -9,7 +9,8 @@ Serialization API
 """""""""""""""""
 
 Class :py:class:`~unidist.core.backends.mpi.core.serialization.MPISerializer` supports data serialization of complex types
-with lambdas, functions, member functions. Moreover, the class support out-of-band data serialization.
+with lambdas, functions, member functions. Moreover, the class support out-of-band data serialization
+for a set of pickle 5 protocol compatible libraries - *pandas* and *numpy*.
 
 API
 ===

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -65,10 +65,10 @@ def is_pickle5_serializable(data):
     """
     is_serializable = False
     for module in available_modules:
-        if module.__name__== "pandas":
+        if module.__name__ == "pandas":
             is_serializable = isinstance(data, module.DataFrame)
         elif module.__name__ == "numpy":
-            is_serializable= isinstance(data, module.ndarray)
+            is_serializable = isinstance(data, module.ndarray)
     return is_serializable
 
 

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -53,7 +53,7 @@ def is_pickle5_serializable(data):
     bool
         ``True`` if the data should be serialized with pickle using protocol 5 (out-of-band data).
     """
-    return hasattr(data, "__reduce_ex__") and inspect.ismethod(
+    return hasattr(data, "__reduce_ex__") and inspect.isroutine(
         getattr(data, "__reduce_ex__")
     )
 

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -66,7 +66,7 @@ def is_pickle5_serializable(data):
     is_serializable = False
     for module in available_modules:
         if module.__name__ == "pandas":
-            is_serializable = isinstance(data, module.DataFrame)
+            is_serializable = isinstance(data, (module.DataFrame, module.Series))
         elif module.__name__ == "numpy":
             is_serializable = isinstance(data, module.ndarray)
     return is_serializable

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -53,8 +53,10 @@ def is_pickle5_serializable(data):
     bool
         ``True`` if the data should be serialized with pickle using protocol 5 (out-of-band data).
     """
-    return hasattr(data, "__reduce_ex__") and inspect.isroutine(
-        getattr(data, "__reduce_ex__")
+    return (
+        not (inspect.isfunction(data) or inspect.isbuiltin(data))
+        and hasattr(data, "__reduce_ex__")
+        and inspect.isroutine(getattr(data, "__reduce_ex__"))
     )
 
 

--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -24,10 +24,10 @@ import gc  # msgpack optimization
 
 # Pickle 5 protocol compatible types check
 compatible_modules = ("pandas", "numpy")
-available_modules = {}
-for mod_name in compatible_modules:
+available_modules = []
+for module_name in compatible_modules:
     try:
-        available_modules[mod_name] = importlib.import_module(mod_name)
+        available_modules.append(importlib.import_module(module_name))
     except ModuleNotFoundError:
         pass
 
@@ -63,14 +63,13 @@ def is_pickle5_serializable(data):
     bool
         ``True`` if the data should be serialized with pickle using protocol 5 (out-of-band data).
     """
-    is_pandas_instance = False
-    is_numpy_instance = False
-    for mod_name in available_modules:
-        if mod_name == "pandas":
-            is_pandas_instance = isinstance(data, available_modules[mod_name].DataFrame)
-        elif mod_name == "numpy":
-            is_numpy_instance = isinstance(data, available_modules[mod_name].ndarray)
-    return is_pandas_instance or is_numpy_instance
+    is_serializable = False
+    for module in available_modules:
+        if module.__name__== "pandas":
+            is_serializable = isinstance(data, module.DataFrame)
+        elif module.__name__ == "numpy":
+            is_serializable= isinstance(data, module.ndarray)
+    return is_serializable
 
 
 class MPISerializer:


### PR DESCRIPTION
```inspect.isroutine``` API may detect build-in methods, that are used in numpy library