### PR TITLE
FIX-#91: Add readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+sphinx:
+   configuration: docs/conf.py
+
+formats:
+  - epub
+  - pdf
+
+python:
+   install:
+   - requirements: requirements.txt


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

## What do these changes do?

PR adds `.readthedocs.yaml` configuration file. Only one difference from the main doc building flow is using python3.8 instead of using 3.7 by default. In case of using python3.7 we have documentation built failed because MPI backend in this case requires optional `pickle5` package. Updating python version to 3.8 is a way to fix this.
<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #91  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
