### PR TITLE
FIX-#111: Fix warning when building MPI docs

### DIFF
--- a/docs/flow/unidist/core/backends/mpi/core/communication.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/communication.rst
@@ -24,9 +24,16 @@ Several levels of serialization handle this case, including `msgpack`, `cloudpic
 `pickle` library uses protocol 5 for out-of-band buffers serialization for performance reasons.
 :py:func:`~unidist.core.backends.mpi.core.communication.isend_complex_operation` is an asynchronous interface for sending data.
 
-.. autofunction:: unidist.core.backends.mpi.core.communication.recv_complex_operation
+.. autofunction:: unidist.core.backends.mpi.core.communication.send_complex_data
+.. autofunction:: unidist.core.backends.mpi.core.communication.recv_complex_data
 .. autofunction:: unidist.core.backends.mpi.core.communication.send_complex_operation
 .. autofunction:: unidist.core.backends.mpi.core.communication.isend_complex_operation
+.. autofunction:: unidist.core.backends.mpi.core.communication.send_remote_task_operation
+
+Complex operations as above, but operating with a bytearray of already serialized data.
+
+.. autofunction:: unidist.core.backends.mpi.core.communication.send_serialized_operation
+.. autofunction:: unidist.core.backends.mpi.core.communication.recv_serialized_data
 
 To reduce possible contention, MPI communication module supports custom receive data functions with a busy-wait loop underneath.
 


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
