### PR TITLE
FIX-#124: Set `max_retries=0` for Ray backend

### DIFF
--- a/unidist/core/backends/ray/remote_function.py
+++ b/unidist/core/backends/ray/remote_function.py
@@ -66,7 +66,10 @@ class RayRemoteFunction(RemoteFunction):
             resources = self._resources
 
         obj_ref = self._remote_function.options(
-            num_cpus=num_cpus, num_returns=num_returns, resources=resources
+            num_cpus=num_cpus,
+            num_returns=num_returns,
+            resources=resources,
+            max_retries=0,
         ).remote(*args, **kwargs)
 
         if num_returns == 1:


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

## What do these changes do?

<!-- Please give a short brief about these changes. -->
PR set parameter `max_retries` of Ray remote function to 0 to be aligned with other backends. It doesn't affect modin tests.

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #124 ? <!-- issue must be created for each patch -->
- [ ] tests ~added~ and passing
- [ ] ~module layout described at `docs/developer/architecture.rst` is up-to-date~ <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
