### PR TITLE
FIX-#142: Fix `flake8` CI fail

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@ max-line-length = 88
 ignore = E203, E266, E501, W503
 select = B,C,E,F,W,T4,B9
 per-file-ignores =
-    versioneer.py:T001
-    unidist/_version.py:T001
+    versioneer.py:T201
+    unidist/_version.py:T201
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #142 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
