### PR TITLE
FIX-#175; FIX-#178: Fix nested remote calls of remote tasks and actor methods

### DIFF
--- a/unidist/core/backends/mpi/core/controller/common.py
+++ b/unidist/core/backends/mpi/core/controller/common.py
@@ -24,14 +24,16 @@ class RoundRobin:
 
     def __init__(self):
         self.rank_to_schedule = itertools.cycle(
-            [
+            (
                 rank
                 for rank in range(
                     initial_worker_number,
                     communication.MPIState.get_instance().world_size,
                 )
+                # check if a rank to schedule is not equal to the rank
+                # of the current process to not get into recursive scheduling
                 if rank != communication.MPIState.get_instance().rank
-            ]
+            )
         )
 
     @classmethod
@@ -84,7 +86,10 @@ def request_worker_data(data_id):
     operation_data = {
         "source": mpi_state.rank,
         "id": data_id.base_data_id(),
-        "blocked": True,
+        # set `is_blocking_op` to `True` to tell a worker
+        # to send the data directly to the requester
+        # without any delay
+        "is_blocking_op": True,
     }
     communication.send_simple_operation(
         mpi_state.comm,

--- a/unidist/core/backends/mpi/core/controller/common.py
+++ b/unidist/core/backends/mpi/core/controller/common.py
@@ -24,9 +24,14 @@ class RoundRobin:
 
     def __init__(self):
         self.rank_to_schedule = itertools.cycle(
-            range(
-                initial_worker_number, communication.MPIState.get_instance().world_size
-            )
+            [
+                rank
+                for rank in range(
+                    initial_worker_number,
+                    communication.MPIState.get_instance().world_size,
+                )
+                if rank != communication.MPIState.get_instance().rank
+            ]
         )
 
     @classmethod
@@ -79,6 +84,7 @@ def request_worker_data(data_id):
     operation_data = {
         "source": mpi_state.rank,
         "id": data_id.base_data_id(),
+        "blocked": True,
     }
     communication.send_simple_operation(
         mpi_state.comm,

--- a/unidist/core/backends/mpi/core/worker/loop.py
+++ b/unidist/core/backends/mpi/core/worker/loop.py
@@ -72,7 +72,7 @@ def worker_loop():
         elif operation_type == common.Operation.GET:
             request = communication.recv_simple_operation(mpi_state.comm, source_rank)
             request_store.process_get_request(
-                request["source"], request["id"], request["blocked"]
+                request["source"], request["id"], request["is_blocking_op"]
             )
 
         elif operation_type == common.Operation.PUT_DATA:

--- a/unidist/core/backends/mpi/core/worker/loop.py
+++ b/unidist/core/backends/mpi/core/worker/loop.py
@@ -71,7 +71,9 @@ def worker_loop():
 
         elif operation_type == common.Operation.GET:
             request = communication.recv_simple_operation(mpi_state.comm, source_rank)
-            request_store.process_get_request(request["source"], request["id"])
+            request_store.process_get_request(
+                request["source"], request["id"], request["blocked"]
+            )
 
         elif operation_type == common.Operation.PUT_DATA:
             request = communication.recv_complex_data(mpi_state.comm, source_rank)

--- a/unidist/core/backends/mpi/core/worker/request_store.py
+++ b/unidist/core/backends/mpi/core/worker/request_store.py
@@ -191,9 +191,9 @@ class RequestStore:
         data_id: unidist.core.backends.common.data_id.DataID
             `data_id` associated data to request
         is_blocking_op : bool, default: False
-            # Whether the get request should be blocking or not.
-            # If ``True``, the request should be processed immediatly
-            # even for a worker since it can get into controller mode.
+            Whether the get request should be blocking or not.
+            If ``True``, the request should be processed immediatly
+            even for a worker since it can get into controller mode.
 
         Notes
         -----

--- a/unidist/core/backends/mpi/core/worker/request_store.py
+++ b/unidist/core/backends/mpi/core/worker/request_store.py
@@ -178,7 +178,7 @@ class RequestStore:
             self.put(data_id, communication.MPIRank.ROOT, self.REQ_WAIT)
             logger.debug("Pending wait request {} id".format(data_id._id))
 
-    def process_get_request(self, source_rank, data_id):
+    def process_get_request(self, source_rank, data_id, is_blocked=False):
         """
         Satisfy GET operation request from another process.
 
@@ -198,7 +198,7 @@ class RequestStore:
         object_store = ObjectStore.get_instance()
         async_operations = AsyncOperations.get_instance()
         if object_store.contains(data_id):
-            if source_rank == communication.MPIRank.ROOT:
+            if source_rank == communication.MPIRank.ROOT or is_blocked:
                 # Master is blocked by request and has no event loop, no need for OP type
                 operation_data = object_store.get(data_id)
                 communication.send_complex_data(

--- a/unidist/core/backends/mpi/core/worker/request_store.py
+++ b/unidist/core/backends/mpi/core/worker/request_store.py
@@ -190,6 +190,10 @@ class RequestStore:
             Rank number to send data to.
         data_id: unidist.core.backends.common.data_id.DataID
             `data_id` associated data to request
+        is_blocking_op : bool, default: False
+            # Whether the get request should be blocking or not.
+            # If ``True``, the request should be processed immediatly
+            # even for a worker since it can get into controller mode.
 
         Notes
         -----
@@ -199,7 +203,8 @@ class RequestStore:
         async_operations = AsyncOperations.get_instance()
         if object_store.contains(data_id):
             if source_rank == communication.MPIRank.ROOT or is_blocking_op:
-                # Master is blocked by request and has no event loop, no need for OP type
+                # The controller or a requesting worker is blocked by the request
+                # which should be processed immediatly
                 operation_data = object_store.get(data_id)
                 communication.send_complex_data(
                     mpi_state.comm,

--- a/unidist/core/backends/mpi/core/worker/request_store.py
+++ b/unidist/core/backends/mpi/core/worker/request_store.py
@@ -178,7 +178,7 @@ class RequestStore:
             self.put(data_id, communication.MPIRank.ROOT, self.REQ_WAIT)
             logger.debug("Pending wait request {} id".format(data_id._id))
 
-    def process_get_request(self, source_rank, data_id, is_blocked=False):
+    def process_get_request(self, source_rank, data_id, is_blocking_op=False):
         """
         Satisfy GET operation request from another process.
 
@@ -198,7 +198,7 @@ class RequestStore:
         object_store = ObjectStore.get_instance()
         async_operations = AsyncOperations.get_instance()
         if object_store.contains(data_id):
-            if source_rank == communication.MPIRank.ROOT or is_blocked:
+            if source_rank == communication.MPIRank.ROOT or is_blocking_op:
                 # Master is blocked by request and has no event loop, no need for OP type
                 operation_data = object_store.get(data_id)
                 communication.send_complex_data(

--- a/unidist/core/backends/mpi/core/worker/task_store.py
+++ b/unidist/core/backends/mpi/core/worker/task_store.py
@@ -132,6 +132,7 @@ class TaskStore:
         operation_data = {
             "source": communication.MPIState.get_instance().rank,
             "id": data_id,
+            "blocked": False,
         }
         communication.send_simple_operation(
             communication.MPIState.get_instance().comm,

--- a/unidist/core/backends/mpi/core/worker/task_store.py
+++ b/unidist/core/backends/mpi/core/worker/task_store.py
@@ -132,7 +132,7 @@ class TaskStore:
         operation_data = {
             "source": communication.MPIState.get_instance().rank,
             "id": data_id,
-            "blocked": False,
+            "is_blocking_op": False,
         }
         communication.send_simple_operation(
             communication.MPIState.get_instance().comm,

--- a/unidist/test/test_actor.py
+++ b/unidist/test/test_actor.py
@@ -65,8 +65,8 @@ def test_address_space(is_use_options):
 
 
 @pytest.mark.skipif(
-    Backend.get() not in (BackendName.RAY, BackendName.DASK, BackendName.MPI),
-    reason="We only have proper serialization/deserialization for Ray, Dask and MPI actors for now",
+    Backend.get() == BackendName.MP,
+    reason="Proper serialization/deserialization is not supported by MultiProcessing",
 )
 def test_global_capture():
     actor = TestActor.remote(0)
@@ -74,13 +74,7 @@ def test_global_capture():
     @unidist.remote
     def foo():
         object_ref = actor.get_accumulator.remote()
-        # TODO: `unidist.get` hangs on MPI in a remote task
-        # so we just return the actual number from `get_accumulator`.
-        # Return the right flow back when the issue is fixed
-        if Backend.get() == BackendName.MPI:
-            return 0
-        else:
-            return unidist.get(object_ref)
+        return unidist.get(object_ref)
 
     object_ref = foo.remote()
 
@@ -88,8 +82,8 @@ def test_global_capture():
 
 
 @pytest.mark.skipif(
-    Backend.get() not in (BackendName.RAY, BackendName.DASK, BackendName.MPI),
-    reason="We only have proper serialization/deserialization for Ray, Dask and MPI actors for now",
+    Backend.get() == BackendName.MP,
+    reason="Proper serialization/deserialization is not supported by MultiProcessing",
 )
 def test_direct_capture():
     actor = TestActor.remote(0)
@@ -97,13 +91,7 @@ def test_direct_capture():
     @unidist.remote
     def foo(actor):
         object_ref = actor.get_accumulator.remote()
-        # TODO: `unidist.get` hangs on MPI in a remote task
-        # so we just return the actual number from `get_accumulator`.
-        # Return the right flow back when the issue is fixed
-        if Backend.get() == BackendName.MPI:
-            return 0
-        else:
-            return unidist.get(object_ref)
+        return unidist.get(object_ref)
 
     object_ref = foo.remote(actor)
 

--- a/unidist/test/test_actor.py
+++ b/unidist/test/test_actor.py
@@ -66,7 +66,7 @@ def test_address_space(is_use_options):
 
 @pytest.mark.skipif(
     Backend.get() == BackendName.MP,
-    reason="Proper serialization/deserialization is not supported by MultiProcessing",
+    reason="Proper serialization/deserialization is not implemented yet for multiprocessing",
 )
 def test_global_capture():
     actor = TestActor.remote(0)
@@ -83,7 +83,7 @@ def test_global_capture():
 
 @pytest.mark.skipif(
     Backend.get() == BackendName.MP,
-    reason="Proper serialization/deserialization is not supported by MultiProcessing",
+    reason="Proper serialization/deserialization is not implemented yet for multiprocessing",
 )
 def test_direct_capture():
     actor = TestActor.remote(0)

--- a/unidist/test/test_task.py
+++ b/unidist/test/test_task.py
@@ -79,3 +79,12 @@ def test_exception():
 
 def test_return_none():
     assert_equal(task_return_none.remote(), None)
+
+
+def test_internal_remote():
+    @unidist.remote
+    def foo(x):
+        o_r = task.remote(x)
+        return unidist.get(o_r) + 10
+
+    assert_equal(foo.remote(5), 35)

--- a/unidist/test/test_task.py
+++ b/unidist/test/test_task.py
@@ -86,7 +86,7 @@ def test_return_none():
 
 @pytest.mark.skipif(
     Backend.get() == BackendName.MP,
-    reason="Run remote task inside of another remote task is not supported by MultiProcessing",
+    reason="Run of a remote task inside of another one is not implemented yet for multiprocessing",
 )
 def test_internal_remote():
     @unidist.remote

--- a/unidist/test/test_task.py
+++ b/unidist/test/test_task.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
+import pytest
 
 import unidist
+from unidist.config import Backend
+from unidist.core.base.common import BackendName
 from .utils import (
     assert_equal,
     catch_exception,
@@ -81,6 +84,10 @@ def test_return_none():
     assert_equal(task_return_none.remote(), None)
 
 
+@pytest.mark.skipif(
+    Backend.get() == BackendName.MP,
+    reason="Run remote task inside of another remote task is not supported by MultiProcessing",
+)
 def test_internal_remote():
     @unidist.remote
     def foo(x):


### PR DESCRIPTION
Signed-off-by: Kirill Suvorov <kirill.suvorov.aleksandrovich@intel.com>

## What do these changes do?

When the get command is called internally, the worker expects a result message but receives a PUT command.
To fix this, a **blocked** parameter is added to the GET message (in MPI communication). When this parameter is set True, the result is sent directly without the PUT command.
