### PR TITLE
FIX-#187: Make `Data_ID` unique for different workers on MPI backend

### DIFF
--- a/unidist/core/backends/mpi/core/controller/object_store.py
+++ b/unidist/core/backends/mpi/core/controller/object_store.py
@@ -8,6 +8,7 @@ import weakref
 from collections import defaultdict
 
 import unidist.core.backends.mpi.core.common as common
+import unidist.core.backends.mpi.core.communication as communication
 
 
 class ObjectStore:
@@ -167,7 +168,7 @@ class ObjectStore:
         unidist.core.backends.mpi.core.common.MasterDataID
             Unique data ID instance.
         """
-        data_id = self._data_id_counter
+        data_id = f"RANK_{communication.MPIState.get_instance().rank}_ID_{self._data_id_counter}"
         self._data_id_counter += 1
         return common.MasterDataID(data_id, gc)
 

--- a/unidist/core/backends/mpi/core/controller/object_store.py
+++ b/unidist/core/backends/mpi/core/controller/object_store.py
@@ -168,7 +168,7 @@ class ObjectStore:
         unidist.core.backends.mpi.core.common.MasterDataID
             Unique data ID instance.
         """
-        data_id = f"RANK_{communication.MPIState.get_instance().rank}_ID_{self._data_id_counter}"
+        data_id = f"rank_{communication.MPIState.get_instance().rank}_id_{self._data_id_counter}"
         self._data_id_counter += 1
         return common.MasterDataID(data_id, gc)
 


### PR DESCRIPTION
Signed-off-by: Kirill Suvorov <kirill.suvorov@intel.com>

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #187 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
