### PR TITLE
FEAT-#204: Allow `PERF` prefix in the commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,6 +5,6 @@ module.exports = {
 		"header-max-length": [2, "always", 88],
 		"signed-off-by": [2, "always", "Signed-off-by"],
 		"jira-task-id-max-length": [0, "always", 10],
-		"jira-task-id-project-key": [2, "always", ["FEAT", "DOCS", "FIX", "REFACTOR", "TEST"]],
+		"jira-task-id-project-key": [2, "always", ["FEAT", "DOCS", "FIX", "REFACTOR", "TEST", "PERF"]],
 	}
 }

--- a/docs/developer/contributing.rst
+++ b/docs/developer/contributing.rst
@@ -88,6 +88,7 @@ message can be one of the following:
 * FIX: A bugfix contribution
 * REFACTOR: Moving or removing code without change in functionality
 * TEST: Test updates or improvements
+* PERF: Performance enhancements
 
 The ``#9999`` component of the commit message should be the issue number in the unidist
 GitHub issue tracker: https://github.com/modin-project/unidist/issues. This is important


### PR DESCRIPTION
Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #204  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
