### PR TITLE
FIX-#233: Fix passing MpiHosts config to workers initialization

### DIFF
--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -92,7 +92,7 @@ def init():
             if IsMpiSpawnWorkers.get_value_source() != ValueSource.DEFAULT:
                 py_str += [f"cfg.IsMpiSpawnWorkers.put({IsMpiSpawnWorkers.get()})"]
             if MpiHosts.get_value_source() != ValueSource.DEFAULT:
-                py_str += [f"cfg.MpiHosts.put({MpiHosts.get()})"]
+                py_str += [f"cfg.MpiHosts.put('{MpiHosts.get()}')"]
             if CpuCount.get_value_source() != ValueSource.DEFAULT:
                 py_str += [f"cfg.CpuCount.put({CpuCount.get()})"]
             if MpiPickleThreshold.get_value_source() != ValueSource.DEFAULT:


### PR DESCRIPTION
Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #233  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
