### PR TITLE
FIX-#250: Replace lint-commit to check-pr-title in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - run: flake8 --enable=T .
 
   test-ubuntu:
-    needs: [lint-commit, lint-black, lint-flake8]
+    needs: [check-pr-title, lint-black, lint-flake8]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -88,7 +88,7 @@ jobs:
         if: matrix.backend == 'mpi'
 
   test-windows:
-    needs: [lint-commit, lint-black, lint-flake8]
+    needs: [check-pr-title, lint-black, lint-flake8]
     runs-on: windows-latest
     defaults:
       run:


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #250  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
