### PR TITLE
FIX-#283: Exit monitor and worker processes in SPMD mode

### DIFF
--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -200,6 +200,8 @@ def init():
         from unidist.core.backends.mpi.core.monitor import monitor_loop
 
         monitor_loop()
+        if IsMpiSpawnWorkers.get():
+            sys.exit()
         return
 
     if mpi_state.rank not in (
@@ -209,6 +211,8 @@ def init():
         from unidist.core.backends.mpi.core.worker.loop import worker_loop
 
         asyncio.run(worker_loop())
+        if IsMpiSpawnWorkers.get():
+            sys.exit()
         return
 
 

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -200,7 +200,7 @@ def init():
         from unidist.core.backends.mpi.core.monitor import monitor_loop
 
         monitor_loop()
-        if IsMpiSpawnWorkers.get():
+        if not IsMpiSpawnWorkers.get():
             sys.exit()
         return
 
@@ -211,7 +211,7 @@ def init():
         from unidist.core.backends.mpi.core.worker.loop import worker_loop
 
         asyncio.run(worker_loop())
-        if IsMpiSpawnWorkers.get():
+        if not IsMpiSpawnWorkers.get():
             sys.exit()
         return
 

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -200,6 +200,9 @@ def init():
         from unidist.core.backends.mpi.core.monitor import monitor_loop
 
         monitor_loop()
+        # If the user executes a program in SPMD mode,
+        # we do not want workers to continue the flow after `unidist.init()`
+        # so just killing them.
         if not IsMpiSpawnWorkers.get():
             sys.exit()
         return
@@ -211,6 +214,9 @@ def init():
         from unidist.core.backends.mpi.core.worker.loop import worker_loop
 
         asyncio.run(worker_loop())
+        # If the user executes a program in SPMD mode,
+        # we do not want workers to continue the flow after `unidist.init()`
+        # so just killing them.
         if not IsMpiSpawnWorkers.get():
             sys.exit()
         return


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->
Added sys.exit() calls to exit monitor and worker processes in SPMD mode as the code was not exiting when the loops ended but went ahead with execution and tried to execute unidist functions again in each worker or monitor.

- [ ] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 .`
- [ ] passes `black .`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #283? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
