### PR TITLE
DOCS-#299: Extend troubleshooting page as to MPI errors

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -58,4 +58,93 @@ Open MPI library. If you are using a conda environment, then the required path w
 
   mpiexec -n 1 --prefix $CONDA_PATH/envs/<ENV_NAME> python script.py
 
+Error when using MPI backend: ``mpi4py.MPI.Exception: MPI_ERR_SPAWN: could not spawn processes``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+This error usually happens on Open MPI when you try to start the number of workers exceeding the number of physical cores.
+Open MPI binds workers to physical cores by default.
+
+.. code-block:: bash
+
+  mpi4py.MPI.Exception: MPI_ERR_SPAWN: could not spawn processes
+  --------------------------------------------------------------------------
+  Primary job  terminated normally, but 1 process returned
+  a non-zero exit code. Per user-direction, the job has been aborted.
+  --------------------------------------------------------------------------
+  --------------------------------------------------------------------------
+  mpiexec detected that one or more processes exited with non-zero status, thus causing
+  the job to be terminated. The first process to do so was:
+
+    Process name: [[35427,1],0]
+    Exit code:    1
+  --------------------------------------------------------------------------
+
+**Solution**
+
+You should add one of the flags below to ``mpiexec`` command when running your application.
+
+* ``--bind-to hwthread``
+* ``--use-hwthread-cpus``
+* ``--oversubscribe``
+
+.. code-block:: bash
+
+  mpiexec -n 1 --bind-to hwthread python script.py
+
+To get more information about the flags refer to `Open MPI's mpiexec`_ command documentation.
+
+Error when using MPI backend: ``There are not enough slots available in the system to satisfy the <N> slots``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+This error usually happens on Open MPI when you try to start the number of workers exceeding the number of physical cores.
+Open MPI binds workers to physical cores by default.
+
+.. code-block:: bash
+
+  --------------------------------------------------------------------------
+  There are not enough slots available in the system to satisfy the <N>
+  slots that were requested by the application:
+
+    python
+
+  Either request fewer slots for your application, or make more slots
+  available for use.
+
+  A "slot" is the Open MPI term for an allocatable unit where we can
+  launch a process.  The number of slots available are defined by the
+  environment in which Open MPI processes are run:
+
+    1. Hostfile, via "slots=N" clauses (N defaults to number of
+      processor cores if not provided)
+    2. The --host command line parameter, via a ":N" suffix on the
+      hostname (N defaults to 1 if not provided)
+    3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
+    4. If none of a hostfile, the --host command line parameter, or an
+      RM is present, Open MPI defaults to the number of processor cores
+
+  In all the above cases, if you want Open MPI to default to the number
+  of hardware threads instead of the number of processor cores, use the
+  --use-hwthread-cpus option.
+
+  Alternatively, you can use the --oversubscribe option to ignore the
+  number of available slots when deciding the number of processes to
+  launch.
+  --------------------------------------------------------------------------
+
+**Solution**
+
+You should add one of the flags below to ``mpiexec`` command when running your application to allow Open MPI
+to start the number of workers exceeding the number of physical cores.
+
+* ``--bind-to hwthread``
+* ``--use-hwthread-cpus``
+* ``--oversubscribe``
+
+.. code-block:: bash
+
+  mpiexec -n 1 --bind-to hwthread python script.py
+
+To get more information about the flags refer to `Open MPI's mpiexec`_ command documentation.
+
+.. _`Open MPI's mpiexec`: https://www.open-mpi.org/doc/v3.1/man1/mpiexec.1.php
 .. _`issue`: https://github.com/modin-project/unidist/issues


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #299, #298 <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
