### PR TITLE
DOCS-#303: Fix a typo in unidist_on_mpi.rst

### DIFF
--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -67,7 +67,7 @@ without using ``mpiexec`` command so you can run unidist on Intel MPI just with:
 
 Refer to ``Using intel channel`` section of :doc:`Installation </installation>` page on how to install Intel MPI implementation to use it with unidist.
 
-SMPD model
+SPMD model
 ----------
 
 First of all, to run unidist on MPI in a single node using `SPMD model <https://en.wikipedia.org/wiki/Single_program,_multiple_data>`_,


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #303  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
