### PR TITLE
FEAT-#308: Add monitor to each host in the cluster

### DIFF
--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -75,6 +75,22 @@ def log_operation(op_type, status):
     )
 
 
+def is_internal_host_communication_supported():
+    """
+    Check if the Unidist on MPI support internal host communication
+
+    Returns
+    -------
+    bool
+        True or False.
+
+    Notes
+    -----
+    MPI prior to the 3.0 standard does not support shared memory and splitting the communicator into the host.
+    """
+    return MPI.VERSION >= 3
+
+
 class MPIState:
     """
     The class holding MPI information.
@@ -108,11 +124,10 @@ class MPIState:
         self.comm = comm
         self.rank = comm.Get_rank()
 
-        if MPI.VERSION < 3:
-            # MPI prior to the 3.0 standard does not support splitting the communicator into host and shared memory.
-            self.host_comm = None
-        else:
+        if is_internal_host_communication_supported():
             self.host_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
+        else:
+            self.host_comm = None
 
         self.host = socket.gethostbyname(socket.gethostname())
         self.world_size = comm.Get_size()

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -91,12 +91,18 @@ class MPIState:
 
     __instance = None
 
-    def __init__(self, comm, host_comm):
+    def __init__(self, comm):
         # attributes get actual values when MPI is initialized in `init` function
         self.comm = comm
-        self.host_comm = host_comm
         self.rank = comm.Get_rank()
-        self.host_rank = host_comm.Get_rank()
+
+        if MPI.VERSION >= 3:
+            self.host_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
+            self.host_rank = self.host_comm.Get_rank()
+        else:
+            self.host_comm = None
+            self.host_rank = self.rank
+
         self.host = socket.gethostbyname(socket.gethostname())
         self.world_size = comm.Get_size()
         self.topology = self.__get_topology()

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -86,7 +86,7 @@ def is_internal_host_communication_supported():
 
     Notes
     -----
-    MPI prior to the 3.0 standard does not support shared memory and splitting the communicator into the host.
+    Prior to the MPI 3.0 standard there is no support for shared memory.
     """
     return MPI.VERSION >= 3
 
@@ -103,15 +103,15 @@ class MPIState:
     Attributes
     ----------
     comm : mpi4py.MPI.Comm
-        MPI communicator.
+        Global MPI communicator.
     host_comm : mpi4py.MPI.Comm
-        Splited MPI communicator for current host
+        MPI subcommunicator for the current host.
     rank : int
         Rank of a process.
-    world_sise : int
+    world_size : int
         Number of processes.
     host : str
-        IP-address of current host
+        IP-address of the current host.
     topology : dict
         Dictionary, containing workers ranks assignments by IP-addresses in
         the form: `{"node_ip0": [rank_2, rank_3, ...], "node_ip1": [rank_i, ...], ...}`.
@@ -123,14 +123,13 @@ class MPIState:
         # attributes get actual values when MPI is initialized in `init` function
         self.comm = comm
         self.rank = comm.Get_rank()
+        self.world_size = comm.Get_size()
 
         if is_internal_host_communication_supported():
             self.host_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
         else:
             self.host_comm = None
-
         self.host = socket.gethostbyname(socket.gethostname())
-        self.world_size = comm.Get_size()
 
         # Get topology of MPI cluster.
         host_rank = (

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -200,9 +200,7 @@ def init():
     if parent_comm != MPI.COMM_NULL:
         comm = parent_comm.Merge(high=True)
 
-    host_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
-
-    mpi_state = communication.MPIState.get_instance(comm, host_comm)
+    mpi_state = communication.MPIState.get_instance(comm)
 
     global is_mpi_initialized
     if not is_mpi_initialized:

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -163,7 +163,7 @@ def init():
             hosts = MpiHosts.get()
             info = MPI.Info.Create()
             host_list = hosts.split(",") if hosts is not None else ["localhost"]
-            hosts_count = len(host_list)
+            host_count = len(host_list)
 
             if communication.is_internal_host_communication_supported():
                 # +1 for monitor process on each host
@@ -171,17 +171,17 @@ def init():
             else:
                 # +1 for just a single process monitor
                 nprocs_to_spawn = cpu_count + 1
-            if hosts_count > 1:
+            if host_count > 1:
                 if "Open MPI" in MPI.Get_library_version():
                     workers_per_host = [
-                        int(nprocs_to_spawn / hosts_count)
-                        + (1 if i < nprocs_to_spawn % hosts_count else 0)
-                        for i in range(hosts_count)
+                        int(nprocs_to_spawn / host_count)
+                        + (1 if i < nprocs_to_spawn % host_count else 0)
+                        for i in range(host_count)
                     ]
                     hosts = ",".join(
                         [
                             f"{host_list[i]}:{workers_per_host[i]}"
-                            for i in range(hosts_count)
+                            for i in range(host_count)
                         ]
                     )
                     info.Set("add-host", hosts)

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -138,7 +138,6 @@ def init():
     # path to dynamically spawn MPI processes
     if rank == 0 and parent_comm == MPI.COMM_NULL:
         if IsMpiSpawnWorkers.get():
-            nprocs_to_spawn = CpuCount.get() + 1  # +1 for monitor process
             args = _get_py_flags()
             args += ["-c"]
             py_str = [
@@ -160,15 +159,20 @@ def init():
             py_str = "; ".join(py_str)
             args += [py_str]
 
+            cpu_count = CpuCount.get()
             hosts = MpiHosts.get()
             info = MPI.Info.Create()
+            host_list = hosts.split(",") if hosts is not None else ["localhost"]
+            hosts_count = len(host_list)
+            # +1 for monitor process on each host
+            nprocs_to_spawn = cpu_count + len(host_list)
             if hosts:
                 if "Open MPI" in MPI.Get_library_version():
                     host_list = str(hosts).split(",")
                     workers_per_host = [
-                        int(nprocs_to_spawn / len(host_list))
-                        + (1 if i < nprocs_to_spawn % len(host_list) else 0)
-                        for i in range(len(host_list))
+                        int(nprocs_to_spawn / hosts_count)
+                        + (1 if i < nprocs_to_spawn % hosts_count else 0)
+                        for i in range(hosts_count)
                     ]
                     hosts = ",".join(
                         [
@@ -196,13 +200,9 @@ def init():
     if parent_comm != MPI.COMM_NULL:
         comm = parent_comm.Merge(high=True)
 
-    mpi_state = communication.MPIState.get_instance(
-        comm, comm.Get_rank(), comm.Get_size()
-    )
+    host_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
 
-    global topology
-    if not topology:
-        topology = communication.get_topology()
+    mpi_state = communication.MPIState.get_instance(comm, host_comm)
 
     global is_mpi_initialized
     if not is_mpi_initialized:
@@ -213,8 +213,7 @@ def init():
         signal.signal(signal.SIGTERM, _termination_handler)
         signal.signal(signal.SIGINT, _termination_handler)
         return
-
-    if mpi_state.rank == communication.MPIRank.MONITOR:
+    elif mpi_state.host_rank == communication.MPIRank.MONITOR:
         from unidist.core.backends.mpi.core.monitor import monitor_loop
 
         monitor_loop()
@@ -224,11 +223,7 @@ def init():
         if not IsMpiSpawnWorkers.get():
             sys.exit()
         return
-
-    if mpi_state.rank not in (
-        communication.MPIRank.ROOT,
-        communication.MPIRank.MONITOR,
-    ):
+    else:
         from unidist.core.backends.mpi.core.worker.loop import worker_loop
 
         asyncio.run(worker_loop())
@@ -300,13 +295,19 @@ def cluster_resources():
         Dictionary with cluster nodes info in the form
         `{"node_ip0": {"CPU": x0}, "node_ip1": {"CPU": x1}, ...}`.
     """
-    global topology
-    if not topology:
+    mpi_state = communication.MPIState.get_instance()
+    if mpi_state is None:
         raise RuntimeError("'unidist.init()' has not been called yet")
 
     cluster_resources = defaultdict(dict)
-    for host, ranks_list in topology.items():
-        cluster_resources[host]["CPU"] = len(ranks_list)
+    for host, ranks_list in mpi_state.topology.items():
+        cluster_resources[host]["CPU"] = len(
+            [
+                r
+                for r in ranks_list
+                if r not in (communication.MPIRank.ROOT, communication.MPIRank.MONITOR)
+            ]
+        )
 
     return dict(cluster_resources)
 
@@ -420,17 +421,18 @@ def wait(data_ids, num_returns=1):
         "num_returns": pending_returns,
     }
     mpi_state = communication.MPIState.get_instance()
+    root_monitor = mpi_state.get_monitor_by_worker_rank(communication.MPIRank.ROOT)
     # We use a blocking send and recv here because we have to wait for
     # completion of the communication, which is necessary for the pipeline to continue.
     communication.send_simple_operation(
         mpi_state.comm,
         operation_type,
         operation_data,
-        communication.MPIRank.MONITOR,
+        root_monitor,
     )
     data = communication.mpi_recv_object(
         mpi_state.comm,
-        communication.MPIRank.MONITOR,
+        root_monitor,
     )
     ready.extend(data["ready"])
     not_ready = data["not_ready"]

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -164,8 +164,13 @@ def init():
             info = MPI.Info.Create()
             host_list = hosts.split(",") if hosts is not None else ["localhost"]
             hosts_count = len(host_list)
-            # +1 for monitor process on each host
-            nprocs_to_spawn = cpu_count + len(host_list)
+
+            if communication.is_internal_host_communication_supported():
+                # +1 for monitor process on each host
+                nprocs_to_spawn = cpu_count + len(host_list)
+            else:
+                # +1 for just a single process monitor
+                nprocs_to_spawn = cpu_count + 1
             if hosts_count > 1:
                 if "Open MPI" in MPI.Get_library_version():
                     workers_per_host = [

--- a/unidist/core/backends/mpi/core/worker/task_store.py
+++ b/unidist/core/backends/mpi/core/worker/task_store.py
@@ -282,11 +282,14 @@ class TaskStore:
                 # Monitor the task execution
                 # We use a blocking send here because we have to wait for
                 # completion of the communication, which is necessary for the pipeline to continue.
+                root_monitor = mpi_state.get_monitor_by_worker_rank(
+                    communication.MPIRank.ROOT
+                )
                 communication.send_simple_operation(
                     communication.MPIState.get_instance().comm,
                     common.Operation.TASK_DONE,
                     completed_data_ids,
-                    communication.MPIRank.MONITOR,
+                    root_monitor,
                 )
 
             async_task = asyncio.create_task(execute())
@@ -351,11 +354,14 @@ class TaskStore:
             # Monitor the task execution.
             # We use a blocking send here because we have to wait for
             # completion of the communication, which is necessary for the pipeline to continue.
+            root_monitor = mpi_state.get_monitor_by_worker_rank(
+                communication.MPIRank.ROOT
+            )
             communication.send_simple_operation(
                 communication.MPIState.get_instance().comm,
                 common.Operation.TASK_DONE,
                 completed_data_ids,
-                communication.MPIRank.MONITOR,
+                root_monitor,
             )
 
     def process_task_request(self, request):


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #308 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
