### PR TITLE
FIX-#296: Make workers exit the loop correctly

### DIFF
--- a/docs/flow/unidist/core/backends/mpi/core/communication.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/communication.rst
@@ -23,7 +23,7 @@ Simple operations involve send/receive objects of standard Python data types.
 .. autofunction:: unidist.core.backends.mpi.core.communication.mpi_recv_buffer
 .. autofunction:: unidist.core.backends.mpi.core.communication.send_simple_operation
 .. autofunction:: unidist.core.backends.mpi.core.communication.isend_simple_operation
-.. autofunction:: unidist.core.backends.mpi.core.communication.recv_simple_operation
+.. autofunction:: unidist.core.backends.mpi.core.communication.mpi_recv_object
 
 Complex operations involve send/receive objects of custom data types, functions and classes with native buffers support.
 Several levels of serialization handle this case, including `msgpack`, `cloudpickle` and `pickle` libraries.

--- a/docs/flow/unidist/core/backends/mpi/core/communication.rst
+++ b/docs/flow/unidist/core/backends/mpi/core/communication.rst
@@ -43,4 +43,4 @@ Complex operations as above, but operating with a bytearray of already serialize
 To reduce possible contention, MPI communication module supports custom receive data functions with a busy-wait loop underneath.
 
 .. autofunction:: unidist.core.backends.mpi.core.communication.mpi_busy_wait_recv
-.. autofunction:: unidist.core.backends.mpi.core.communication.recv_operation_type
+.. autofunction:: unidist.core.backends.mpi.core.communication.mpi_recv_operation

--- a/unidist/core/backends/mpi/core/async_operations.py
+++ b/unidist/core/backends/mpi/core/async_operations.py
@@ -61,9 +61,8 @@ class AsyncOperations:
         ]
 
     def finish(self):
-        """Cancel all MPI async send requests."""
-        for handler, data in self._send_async_handlers:
+        """Finish all MPI async send requests."""
+        for handler, _ in self._send_async_handlers:
             logger.debug("WAIT ASYNC HANDLER {}".format(handler))
-            handler.Cancel()
             handler.Wait()
         self._send_async_handlers.clear()

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -65,12 +65,16 @@ class Operation:
 
 class MPITag:
     """
-    Class that describes tags that are used internally.
+    Class that describes tags that are used internally for communications.
 
     Attributes
     ----------
     OPERATION : int, default: 111
         The tag for send/recv of an operation type.
+    OBJECT : int, default: 112
+        The tag for send/recv of a regular Python object.
+    BUFFER : int, default: 113
+        The tag for send/recv of a buffer-like object.
     """
 
     OPERATION = 111

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -17,7 +17,7 @@ class Operation:
     Attributes
     ----------
     EXECUTE : int, default 1
-        Execute remote task.
+        Execute a remote task.
     GET : int, default 2
         Return local data to a requester.
     PUT_DATA : int, default 3
@@ -35,9 +35,14 @@ class Operation:
     TASK_DONE : int, default 9
         Increment global task counter.
     GET_TASK_COUNT : int, default 10
-        Exit event loop.
-    CANCEL : int, default 11
         Return global task counter to a requester.
+    CANCEL : int, default 11
+        Send a message to a worker to exit the event loop.
+    READY_TO_SHUTDOWN : int, default 12
+        Send a message to monitor from a worker,
+        which is ready to shutdown.
+    SHUTDOWN : int, default 13
+        Send a message from monitor to a worker to shutdown.
     """
 
     ### --- Master/worker operations --- ###
@@ -54,6 +59,23 @@ class Operation:
     GET_TASK_COUNT = 10
     ### --- Common operations --- ###
     CANCEL = 11
+    READY_TO_SHUTDOWN = 12
+    SHUTDOWN = 13
+
+
+class MPITag:
+    """
+    Class that describes tags that are used internally.
+
+    Attributes
+    ----------
+    OPERATION : int, default: 111
+        The tag for send/recv of an operation type.
+    """
+
+    OPERATION = 111
+    OBJECT = 112
+    BUFFER = 113
 
 
 default_class_properties = dir(type("dummy", (object,), {}))

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -271,18 +271,16 @@ def shutdown():
         for rank_id in range(communication.MPIRank.FIRST_WORKER, mpi_state.world_size):
             # We use a blocking send here because we have to wait for
             # completion of the communication, which is necessary for the pipeline to continue.
-            communication.mpi_send_object(
+            communication.mpi_send_operation(
                 mpi_state.comm,
                 common.Operation.CANCEL,
                 rank_id,
-                tag=common.MPITag.OPERATION,
             )
             logger.debug("Shutdown rank {}".format(rank_id))
         # Make sure that monitor has sent the shutdown signal to all workers.
         op_type = communication.mpi_recv_object(
             mpi_state.comm,
             communication.MPIRank.MONITOR,
-            tag=common.MPITag.OBJECT,
         )
         if op_type != common.Operation.SHUTDOWN:
             raise ValueError(f"Got wrong operation type {op_type}.")
@@ -433,7 +431,6 @@ def wait(data_ids, num_returns=1):
     data = communication.mpi_recv_object(
         mpi_state.comm,
         communication.MPIRank.MONITOR,
-        tag=common.MPITag.OBJECT,
     )
     ready.extend(data["ready"])
     not_ready = data["not_ready"]

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -264,19 +264,31 @@ def shutdown():
     """
     global is_mpi_shutdown
     if not is_mpi_shutdown:
+        async_operations = AsyncOperations.get_instance()
+        async_operations.finish()
         mpi_state = communication.MPIState.get_instance()
         # Send shutdown commands to all ranks
-        for rank_id in range(communication.MPIRank.MONITOR, mpi_state.world_size):
+        for rank_id in range(communication.MPIRank.FIRST_WORKER, mpi_state.world_size):
             # We use a blocking send here because we have to wait for
             # completion of the communication, which is necessary for the pipeline to continue.
             communication.mpi_send_object(
-                mpi_state.comm, common.Operation.CANCEL, rank_id
+                mpi_state.comm,
+                common.Operation.CANCEL,
+                rank_id,
+                tag=common.MPITag.OPERATION,
             )
             logger.debug("Shutdown rank {}".format(rank_id))
-        async_operations = AsyncOperations.get_instance()
-        async_operations.finish()
+        # Make sure that monitor has sent the shutdown signal to all workers.
+        op_type = communication.mpi_recv_object(
+            mpi_state.comm,
+            communication.MPIRank.MONITOR,
+            tag=common.MPITag.OBJECT,
+        )
+        if op_type != common.Operation.SHUTDOWN:
+            raise ValueError(f"Got wrong operation type {op_type}.")
         if not MPI.Is_finalized():
             MPI.Finalize()
+        logger.debug("Shutdown root")
         is_mpi_shutdown = True
 
 
@@ -418,9 +430,10 @@ def wait(data_ids, num_returns=1):
         operation_data,
         communication.MPIRank.MONITOR,
     )
-    data = communication.recv_simple_operation(
+    data = communication.mpi_recv_object(
         mpi_state.comm,
         communication.MPIRank.MONITOR,
+        tag=common.MPITag.OBJECT,
     )
     ready.extend(data["ready"])
     not_ready = data["not_ready"]

--- a/unidist/core/backends/mpi/core/controller/garbage_collector.py
+++ b/unidist/core/backends/mpi/core/controller/garbage_collector.py
@@ -122,16 +122,14 @@ class GarbageCollector:
                     # Compare submitted and executed tasks
                     # We use a blocking send here because we have to wait for
                     # completion of the communication, which is necessary for the pipeline to continue.
-                    communication.mpi_send_object(
+                    communication.mpi_send_operation(
                         mpi_state.comm,
                         common.Operation.GET_TASK_COUNT,
                         communication.MPIRank.MONITOR,
-                        tag=common.MPITag.OPERATION,
                     )
                     executed_task_counter = communication.mpi_recv_object(
                         mpi_state.comm,
                         communication.MPIRank.MONITOR,
-                        tag=common.MPITag.OBJECT,
                     )
 
                     logger.debug(

--- a/unidist/core/backends/mpi/core/controller/garbage_collector.py
+++ b/unidist/core/backends/mpi/core/controller/garbage_collector.py
@@ -126,10 +126,12 @@ class GarbageCollector:
                         mpi_state.comm,
                         common.Operation.GET_TASK_COUNT,
                         communication.MPIRank.MONITOR,
+                        tag=common.MPITag.OPERATION,
                     )
-                    executed_task_counter = communication.recv_simple_operation(
+                    executed_task_counter = communication.mpi_recv_object(
                         mpi_state.comm,
                         communication.MPIRank.MONITOR,
+                        tag=common.MPITag.OBJECT,
                     )
 
                     logger.debug(

--- a/unidist/core/backends/mpi/core/monitor.py
+++ b/unidist/core/backends/mpi/core/monitor.py
@@ -167,7 +167,9 @@ def monitor_loop():
     data_id_tracker = DataIDTracker.get_instance()
     workers_ready_to_shutdown = []
     shutdown_workers = False
-
+    # Once all workers excluding ``Root`` and ``Monitor`` ranks are ready to shutdown,
+    # ``Monitor` sends the shutdown signal to every worker, as well as notifies ``Root`` that
+    # it can exit the program.
     while True:
         # Listen receive operation from any source
         operation_type, source_rank = communication.recv_operation_type(mpi_state.comm)
@@ -201,7 +203,7 @@ def monitor_loop():
             workers_ready_to_shutdown.append(source_rank)
             shutdown_workers = (
                 len(workers_ready_to_shutdown) == mpi_state.world_size - 2
-            )  # "-2" to exclude master and monitor ranks
+            )  # "-2" to exclude ``Root`` and ``Monitor`` ranks
         else:
             raise ValueError(f"Unsupported operation: {operation_type}")
 

--- a/unidist/core/backends/mpi/core/worker/loop.py
+++ b/unidist/core/backends/mpi/core/worker/loop.py
@@ -94,7 +94,7 @@ async def worker_loop():
     while True:
         # Listen receive operation from any source
         operation_type, source_rank = await async_wrap(
-            communication.recv_operation_type
+            communication.mpi_recv_operation
         )(mpi_state.comm)
         w_logger.debug("common.Operation processing - {}".format(operation_type))
 
@@ -119,7 +119,6 @@ async def worker_loop():
             request = communication.mpi_recv_object(
                 mpi_state.comm,
                 source_rank,
-                tag=common.MPITag.OBJECT,
                 cancel_recv=ready_to_shutdown_posted,
             )
             if request is not None and not ready_to_shutdown_posted:
@@ -155,7 +154,6 @@ async def worker_loop():
             request = communication.mpi_recv_object(
                 mpi_state.comm,
                 source_rank,
-                tag=common.MPITag.OBJECT,
                 cancel_recv=ready_to_shutdown_posted,
             )
             if request is not None and not ready_to_shutdown_posted:
@@ -169,16 +167,16 @@ async def worker_loop():
                 )
 
         elif operation_type == common.Operation.WAIT:
-            request = communication.mpi_recv_object(
-                mpi_state.comm, source_rank, tag=common.MPITag.OBJECT
-            )
+            request = communication.mpi_recv_object(mpi_state.comm, source_rank)
             if request is not None and not ready_to_shutdown_posted:
                 w_logger.debug("WAIT for {} id".format(request["id"]._id))
                 request["id"] = object_store.get_unique_data_id(request["id"])
                 request_store.process_wait_request(request["id"])
 
         elif operation_type == common.Operation.ACTOR_CREATE:
-            request = communication.recv_complex_data(mpi_state.comm, source_rank)
+            request = communication.recv_complex_data(
+                mpi_state.comm, source_rank, cancel_recv=ready_to_shutdown_posted
+            )
             if request is not None and not ready_to_shutdown_posted:
                 cls = request["class"]
                 args = request["args"]
@@ -187,7 +185,9 @@ async def worker_loop():
                 actor_map[handler] = cls(*args, **kwargs)
 
         elif operation_type == common.Operation.ACTOR_EXECUTE:
-            request = communication.recv_complex_data(mpi_state.comm, source_rank)
+            request = communication.recv_complex_data(
+                mpi_state.comm, source_rank, cancel_recv=ready_to_shutdown_posted
+            )
 
             if request is not None and not ready_to_shutdown_posted:
                 # Prepare the data
@@ -215,11 +215,10 @@ async def worker_loop():
             task_store.clear_pending_actor_tasks()
             request_store.clear_get_requests()
             request_store.clear_wait_requests()
-            communication.mpi_send_object(
+            communication.mpi_send_operation(
                 mpi_state.comm,
                 common.Operation.READY_TO_SHUTDOWN,
                 communication.MPIRank.MONITOR,
-                tag=common.MPITag.OPERATION,
             )
             ready_to_shutdown_posted = True
         elif operation_type == common.Operation.SHUTDOWN and ready_to_shutdown_posted:

--- a/unidist/core/backends/mpi/core/worker/request_store.py
+++ b/unidist/core/backends/mpi/core/worker/request_store.py
@@ -122,6 +122,15 @@ class RequestStore:
         """
         self._data_requests.discard(data_id)
 
+    def clear_get_requests(self):
+        """Clear blocking and non-blocking get requests."""
+        self._blocking_get_requests.clear()
+        self._nonblocking_get_requests.clear()
+
+    def clear_wait_requests(self):
+        """Clear blocking wait requests requests."""
+        self._blocking_wait_requests.clear()
+
     def check_pending_get_requests(self, data_ids):
         """
         Check if `GET` event on this `data_ids` is waiting to be processed.
@@ -177,6 +186,7 @@ class RequestStore:
                         communication.MPIState.get_instance().comm,
                         data_id,
                         communication.MPIRank.ROOT,
+                        tag=common.MPITag.OBJECT,
                     )
                     del self._blocking_wait_requests[data_id]
         else:
@@ -186,6 +196,7 @@ class RequestStore:
                     communication.MPIState.get_instance().comm,
                     data_ids,
                     communication.MPIRank.ROOT,
+                    tag=common.MPITag.OBJECT,
                 )
                 del self._blocking_wait_requests[data_ids]
 
@@ -211,6 +222,7 @@ class RequestStore:
                 communication.MPIState.get_instance().comm,
                 data_id,
                 communication.MPIRank.ROOT,
+                tag=common.MPITag.OBJECT,
             )
             logger.debug("Wait data {} id is ready".format(data_id._id))
         else:

--- a/unidist/core/backends/mpi/core/worker/request_store.py
+++ b/unidist/core/backends/mpi/core/worker/request_store.py
@@ -186,7 +186,6 @@ class RequestStore:
                         communication.MPIState.get_instance().comm,
                         data_id,
                         communication.MPIRank.ROOT,
-                        tag=common.MPITag.OBJECT,
                     )
                     del self._blocking_wait_requests[data_id]
         else:
@@ -196,7 +195,6 @@ class RequestStore:
                     communication.MPIState.get_instance().comm,
                     data_ids,
                     communication.MPIRank.ROOT,
-                    tag=common.MPITag.OBJECT,
                 )
                 del self._blocking_wait_requests[data_ids]
 
@@ -222,7 +220,6 @@ class RequestStore:
                 communication.MPIState.get_instance().comm,
                 data_id,
                 communication.MPIRank.ROOT,
-                tag=common.MPITag.OBJECT,
             )
             logger.debug("Wait data {} id is ready".format(data_id._id))
         else:

--- a/unidist/core/backends/mpi/core/worker/task_store.py
+++ b/unidist/core/backends/mpi/core/worker/task_store.py
@@ -93,6 +93,14 @@ class TaskStore:
                     updated_list.append(pending_request)
             self._pending_tasks_list = updated_list
 
+    def clear_pending_tasks(self):
+        """
+        Clear a list of pending task execution requests.
+        """
+        w_logger.debug("Clear pending tasks")
+
+        self._pending_tasks_list.clear()
+
     def check_pending_actor_tasks(self):
         """
         Check a list of pending actor task execution requests and process all ready tasks.
@@ -108,6 +116,14 @@ class TaskStore:
                 if pending_request:
                     updated_list.append(pending_request)
             self._pending_actor_tasks_list = updated_list
+
+    def clear_pending_actor_tasks(self):
+        """
+        Clear a list of pending actor task execution requests.
+        """
+        w_logger.debug("Clear pending actor tasks")
+
+        self._pending_actor_tasks_list.clear()
 
     def request_worker_data(self, dest_rank, data_id):
         """
@@ -262,9 +278,7 @@ class TaskStore:
                             object_store.put(data_id, output_values)
                             completed_data_ids = [data_id]
 
-                        RequestStore.get_instance().check_pending_get_requests(
-                            output_data_ids
-                        )
+                RequestStore.get_instance().check_pending_get_requests(output_data_ids)
                 # Monitor the task execution
                 # We use a blocking send here because we have to wait for
                 # completion of the communication, which is necessary for the pipeline to continue.
@@ -333,6 +347,7 @@ class TaskStore:
                         data_id = object_store.get_unique_data_id(output_data_ids)
                         object_store.put(data_id, output_values)
                         completed_data_ids = [data_id]
+            RequestStore.get_instance().check_pending_get_requests(output_data_ids)
             # Monitor the task execution.
             # We use a blocking send here because we have to wait for
             # completion of the communication, which is necessary for the pipeline to continue.
@@ -365,7 +380,11 @@ class TaskStore:
         kwargs = request["kwargs"]
         output_ids = request["output"]
 
+        w_logger.debug("REMOTE task: {}".format(task))
         w_logger.debug("REMOTE args: {}".format(common.unwrapped_data_ids_list(args)))
+        w_logger.debug(
+            "REMOTE kwargs: {}".format(common.unwrapped_data_ids_list(kwargs))
+        )
         w_logger.debug(
             "REMOTE outputs: {}".format(common.unwrapped_data_ids_list(output_ids))
         )


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #296  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
