### PR TITLE
FIX-#318: Do not initialize MPI in serialization.py

### DIFF
--- a/unidist/core/backends/mpi/core/serialization.py
+++ b/unidist/core/backends/mpi/core/serialization.py
@@ -8,7 +8,13 @@ import importlib
 import inspect
 import sys
 from collections.abc import KeysView
-from mpi4py.MPI import memory
+
+try:
+    import mpi4py
+except ImportError:
+    raise ImportError(
+        "Missing dependency 'mpi4py'. Use pip or conda to install it."
+    ) from None
 
 # Serialization libraries
 if sys.version_info[1] < 8:  # check the minor Python version
@@ -25,6 +31,11 @@ import msgpack
 import gc  # msgpack optimization
 
 from unidist.config import MpiPickleThreshold
+
+# TODO: Find a way to move this after all imports
+mpi4py.rc(recv_mprobe=False, initialize=False)
+from mpi4py.MPI import memory  # noqa: E402
+
 
 # Pickle 5 protocol compatible types check
 compatible_modules = ("pandas", "numpy")


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #318  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
