### PR TITLE
FIX-#324: Pin `pydantic<2` to fix CI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   # for development
+  # https://github.com/modin-project/unidist/issues/324
+  - pydantic<2
   - ray-default>=1.13.0
   - dask>=2.22.0
   - distributed>=2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ dask[complete]>=2.22.0
 distributed>=2.22.0
 mpi4py-mpich
 msgpack>=1.0.0
+# https://github.com/modin-project/unidist/issues/324
+pydantic<2
 ray[default]>=1.13.0
 packaging
 psutil

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup, find_packages
 import sys
 import versioneer
 
-ray_deps = ["ray[default]>=1.13.0"]
+# https://github.com/modin-project/unidist/issues/324
+ray_deps = ["ray[default]>=1.13.0", "pydantic<2"]
 dask_deps = ["dask[complete]>=2.22.0", "distributed>=2.22.0"]
 mpi_deps = ["mpi4py-mpich", "msgpack>=1.0.0"]
 if sys.version_info[1] < 8:


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #324  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
