### PR TITLE
FIX-#326: Set `I_MPI_SPAWN` for Intel MPI when using dynamic spawn

### DIFF
--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -81,7 +81,7 @@ you should set the ``UNIDIST_IS_MPI_SPAWN_WORKERS`` environment variable to ``Fa
 
     import os
 
-    os.environ["UNIDIST_IS_MPI_SPAWN_WORKERS"] = False
+    os.environ["UNIDIST_IS_MPI_SPAWN_WORKERS"] = "False"
 
 or set the associated configuration value:
 
@@ -156,7 +156,7 @@ you should set the ``UNIDIST_IS_MPI_SPAWN_WORKERS`` environment variable to ``Fa
 
     import os
 
-    os.environ["UNIDIST_IS_MPI_SPAWN_WORKERS"] = False
+    os.environ["UNIDIST_IS_MPI_SPAWN_WORKERS"] = "False"
 
 or set the associated configuration value:
 

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -4,6 +4,7 @@
 
 """High-level API of MPI backend."""
 
+import os
 import sys
 import atexit
 import signal
@@ -165,8 +166,16 @@ def init():
 
             hosts = MpiHosts.get()
             info = MPI.Info.Create()
+            lib_version = MPI.Get_library_version()
+            if "Intel" in lib_version:
+                # To make dynamic spawn of MPI processes work properly
+                # we should set this environment variable.
+                # See more about Intel MPI environment variables in
+                # https://www.intel.com/content/www/us/en/docs/mpi-library/developer-reference-linux/2021-8/other-environment-variables.html.
+                os.environ["I_MPI_SPAWN"] = "1"
+
             if hosts:
-                if "Open MPI" in MPI.Get_library_version():
+                if "Open MPI" in lib_version:
                     host_list = str(hosts).split(",")
                     workers_per_host = [
                         int(nprocs_to_spawn / len(host_list))


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #326  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
