### PR TITLE
FIX-#345: Test both modes of MPI execution on Linux only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,21 +91,25 @@ jobs:
         if: matrix.backend != 'mpi'
       - run: python -m pytest unidist/test/test_general.py
         if: matrix.backend != 'mpi'
-      # when using a directory to run with mpiexec MPI gets hung after executing tests
-      # so we run the test files one by one
+      # When using a directory to run with mpiexec
+      # MPI gets hung after executing tests
+      # so we run the test files one by one.
+      # We test enabled and disabled shared object store on linux, and
+      # disabled shared object store on Windows as
+      # msmpi doesn't support the shared memory feature.
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=True mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_actor.py
-        if: matrix.backend == 'mpi'
+        if: matrix.backend == 'mpi' && matrix.os != 'windows'
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=False mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_actor.py
         if: matrix.backend == 'mpi'
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=True mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_async_actor.py
-        if: matrix.backend == 'mpi'
+        if: matrix.backend == 'mpi' && matrix.os != 'windows'
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=False mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_async_actor.py
         if: matrix.backend == 'mpi'
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=True mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_task.py
-        if: matrix.backend == 'mpi'
+        if: matrix.backend == 'mpi' && matrix.os != 'windows'
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=False mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_task.py
         if: matrix.backend == 'mpi'
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=True mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_general.py
-        if: matrix.backend == 'mpi'
+        if: matrix.backend == 'mpi' && matrix.os != 'windows'
       - run: UNIDIST_MPI_SHARED_OBJECT_STORE=False mpiexec -n 1 --oversubscribe python -m pytest unidist/test/test_general.py
         if: matrix.backend == 'mpi'


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #345  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
