### PR TITLE
FEAT-#341: Add the ability to specify environment variables for MPI workers

### DIFF
--- a/docs/flow/unidist/config.rst
+++ b/docs/flow/unidist/config.rst
@@ -64,6 +64,8 @@ Unidist Configuration Settings List
 +-------------------------------+-------------------------------------------+--------------------------------------------------------------------------+
 | MpiSharedObjectStoreThreshold | UNIDIST_MPI_SHARED_OBJECT_STORE_THRESHOLD | Minimum size of data to put into the shared object store                 |
 +-------------------------------+-------------------------------------------+--------------------------------------------------------------------------+
+| MpiRuntimeEnv                 | Only the config API is available          | Runtime environment for MPI worker processes                             |
++-------------------------------+-------------------------------------------+--------------------------------------------------------------------------+
 
 Usage Guide
 '''''''''''

--- a/unidist/config/__init__.py
+++ b/unidist/config/__init__.py
@@ -22,6 +22,7 @@ from .backends.mpi import (
     MpiSharedObjectStore,
     MpiSharedObjectStoreMemory,
     MpiSharedObjectStoreThreshold,
+    MpiRuntimeEnv,
 )
 from .parameter import ValueSource
 
@@ -45,4 +46,5 @@ __all__ = [
     "MpiSharedObjectStore",
     "MpiSharedObjectStoreMemory",
     "MpiSharedObjectStoreThreshold",
+    "MpiRuntimeEnv",
 ]

--- a/unidist/config/backends/mpi/__init__.py
+++ b/unidist/config/backends/mpi/__init__.py
@@ -13,6 +13,7 @@ from .envvars import (
     MpiSharedObjectStore,
     MpiSharedObjectStoreMemory,
     MpiSharedObjectStoreThreshold,
+    MpiRuntimeEnv,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "MpiSharedObjectStore",
     "MpiSharedObjectStoreMemory",
     "MpiSharedObjectStoreThreshold",
+    "MpiRuntimeEnv",
 ]

--- a/unidist/config/backends/mpi/envvars.py
+++ b/unidist/config/backends/mpi/envvars.py
@@ -96,3 +96,47 @@ class MpiSharedObjectStoreThreshold(EnvironmentVariable, type=int):
 
     default = 10**5  # 100 KB
     varname = "UNIDIST_MPI_SHARED_OBJECT_STORE_THRESHOLD"
+
+
+class MpiRuntimeEnv:
+    """
+    Runtime environment for MPI worker processes.
+
+    Notes
+    -----
+    This config doesn't have a respective environment variable as
+    it is much more convenient to set a config value using the config API
+    but not through the environment variable.
+    """
+
+    # Possible options for a runtime environment to set
+    env_vars = "env_vars"
+    # Config value
+    _value = {}
+
+    @classmethod
+    def put(cls, value):
+        """
+        Set config value.
+
+        Parameters
+        ----------
+        value : dict
+            Config value to set.
+        """
+        if any([True for option in value if option != cls.env_vars]):
+            raise NotImplementedError(
+                "Any option other than environment variables is not supported yet."
+            )
+        cls._value = value
+
+    @classmethod
+    def get(cls):
+        """
+        Get config value.
+
+        Returns
+        -------
+        dict
+        """
+        return cls._value


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #341  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

** Example of usage **

```python
import os
import unidist
import unidist.config as cfg

cfg.MpiRuntimeEnv.put({"env_vars": {"AAA": 111, "BBB": 222}})

unidist.init()

@unidist.remote
def f():
    return [os.environ.get("AAA"), os.environ.get("BBB")]

o = f.remote()

data = unidist.get(o)
print("remote =", data)
# remote = ['111', '222']
print("main =", [os.environ.get("AAA"), os.environ.get("BBB")])
# main = [None, None]
```
