### PR TITLE
FIX-#354: Fix unidist.wait for MPI backend

### DIFF
--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -468,7 +468,7 @@ def wait(data_ids, num_returns=1):
     local_store = LocalObjectStore.get_instance()
 
     logger.debug("WAIT {} ids".format(common.unwrapped_data_ids_list(data_ids)))
-    for data_id in not_ready:
+    for data_id in not_ready.copy():
         if local_store.contains(data_id):
             ready.append(data_id)
             not_ready.remove(data_id)

--- a/unidist/test/test_general.py
+++ b/unidist/test/test_general.py
@@ -54,6 +54,15 @@ def test_wait():
     assert_equal(len(ready), 2)
     assert_equal(len(not_ready), 0)
 
+    # test for https://github.com/modin-project/unidist/issues/354
+    object_refs = [unidist.put(1), unidist.put(2)]
+    ready, not_ready = unidist.wait(object_refs, num_returns=1)
+    assert_equal(len(ready), 1)
+    assert_equal(len(not_ready), 1)
+    ready, not_ready = unidist.wait(object_refs, num_returns=2)
+    assert_equal(len(ready), 2)
+    assert_equal(len(not_ready), 0)
+
 
 def test_get_ip():
     import socket


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #354  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
