### PR TITLE
FEAT-#347: Get rid of `mpi4py-mpich` dependency

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "mambaforge-22.9"
 
 sphinx:
    configuration: docs/conf.py
@@ -18,6 +18,6 @@ formats:
   - epub
   - pdf
 
-python:
-   install:
-   - requirements: requirements.txt
+# we use dependencies from conda-forge to have a ready-to-use MPI implementation
+conda:
+  environment: environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
+    # We use mambaforge to install packages from conda-forge below
     python: "mambaforge-22.9"
 
 sphinx:
@@ -18,6 +19,8 @@ formats:
   - epub
   - pdf
 
-# we use dependencies from conda-forge to have a ready-to-use MPI implementation
+# We use dependencies from conda-forge to have a ready-to-use MPI implementation.
+# If we tried to install mpi4py from PyPI, installation would fail because
+# mpi4py requires a working MPI implementation installed.
 conda:
   environment: environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,6 +21,6 @@ formats:
 
 # We use dependencies from conda-forge to have a ready-to-use MPI implementation.
 # If we tried to install mpi4py from PyPI, installation would fail because
-# mpi4py requires a working MPI implementation installed.
+# mpi4py requires a working MPI implementation installed beforehand.
 conda:
   environment: environment.yml

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ pip install unidist[ray] # Install unidist with dependencies for Ray backend
 unidist automatically detects which execution backends are installed and uses that for scheduling computation.
 
 **Note:** There are different MPI implementations, each of which can be used as a backend in unidist.
-By default, mapping `unidist[mpi]` installs MPICH on Linux and MacOS and MSMPI on Windows. If you want to use
-a specific version of MPI, you can install the core dependencies of unidist as `pip install unidist` and then
-install the specific version of MPI using pip as shown in the [installation](https://mpi4py.readthedocs.io/en/latest/install.html)
-section of mpi4py documentation.
+Mapping `unidist[mpi]` installs `mpi4py` package, which is just a Python wrapper for MPI.
+To enable unidist on MPI execution you need to have a working MPI implementation and certain software installed.
+Refer to [Installation](https://mpi4py.readthedocs.io/en/latest/install.html) page of the `mpi4py` documentation for details.
+Also, you can find some instructions on [MPI backend](https://unidist.readthedocs.io/en/latest/optimization_notes/mpi.html) page.
 
 #### Using conda
 
@@ -73,10 +73,11 @@ conda install unidist-mpi unidist-dask unidist-ray -c conda-forge
 ```
 
 **Note:** There are different MPI implementations, each of which can be used as a backend in unidist.
-By default, mapping `unidist-mpi` installs MPICH on Linux and MacOS and MSMPI on Windows. If you want to use
-a specific version of MPI, you can install the core dependencies of unidist as `conda install unidist` and then
-install the specific version of MPI using conda as shown in the [installation](https://mpi4py.readthedocs.io/en/latest/install.html)
-section of mpi4py documentation. That said, it is highly encouraged to use your own MPI binaries as stated in the
+By default, mapping `unidist-mpi` installs a default MPI implementation, which comes with `mpi4py` package and is ready to use.
+The conda dependency solver decides on which MPI implementation is to be installed. If you want to use a specific version of MPI,
+you can install the core dependencies for MPI backend and the specific version of MPI as `conda install unidist-mpi <mpi>`
+as shown in the [Installation](https://mpi4py.readthedocs.io/en/latest/install.html)
+page of `mpi4py` documentation. That said, it is highly encouraged to use your own MPI binaries as stated in the
 [Using External MPI Libraries](https://conda-forge.org/docs/user/tipsandtricks.html#using-external-message-passing-interface-mpi-libraries)
 section of the conda-forge documentation in order to get ultimate performance.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ unidist automatically detects which execution backends are installed and uses th
 
 **Note:** There are different MPI implementations, each of which can be used as a backend in unidist.
 Mapping `unidist[mpi]` installs `mpi4py` package, which is just a Python wrapper for MPI.
-To enable unidist on MPI execution you need to have a working MPI implementation and certain software installed.
+To enable unidist on MPI execution you need to have a working MPI implementation and certain software installed beforehand.
 Refer to [Installation](https://mpi4py.readthedocs.io/en/latest/install.html) page of the `mpi4py` documentation for details.
 Also, you can find some instructions on [MPI backend](https://unidist.readthedocs.io/en/latest/optimization_notes/mpi.html) page.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,7 +41,7 @@ scheduling computation!
 .. note::
     There are different MPI implementations, each of which can be used as a backend in unidist.
     Mapping ``unidist[mpi]`` installs ``mpi4py`` package, which is just a Python wrapper for MPI.
-    To enable unidist on MPI execution you need to have a working MPI implementation and certain software installed.
+    To enable unidist on MPI execution you need to have a working MPI implementation and certain software installed beforehand.
     Refer to installation_ page of the `mpi4py` documentation for details.
     Also, you can find some instructions on :doc:`MPI backend </optimization_notes/mpi>` page.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,12 +38,12 @@ If you don't have MPI_, Dask_ or Ray_ installed, you will need to install unidis
 unidist automatically detects which execution backends are installed and uses that for
 scheduling computation!
 
-.. note:: 
+.. note::
     There are different MPI implementations, each of which can be used as a backend in unidist.
-    By default, mapping ``unidist[mpi]`` installs MPICH on Linux and MacOS and MSMPI on Windows. If you want to use
-    a specific version of MPI, you can install the core dependencies of unidist as ``pip install unidist`` and then
-    install the specific version of MPI using pip as shown in the installation_
-    section of mpi4py documentation.
+    Mapping ``unidist[mpi]`` installs ``mpi4py`` package, which is just a Python wrapper for MPI.
+    To enable unidist on MPI execution you need to have a working MPI implementation and certain software installed.
+    Refer to installation_ page of the `mpi4py` documentation for details.
+    Also, you can find some instructions on :doc:`MPI backend </optimization_notes/mpi>` page.
 
 Release candidates
 """"""""""""""""""
@@ -103,11 +103,11 @@ or explicitly:
 
 .. note:: 
     There are different MPI implementations, each of which can be used as a backend in unidist.
-    By default, mapping ``unidist-mpi`` installs MPICH on Linux and MacOS and MSMPI on Windows. If you want to use
-    a specific version of MPI, you can install the core dependencies of unidist as ``conda install unidist`` and then
-    install the specific version of MPI using conda as shown in the installation_
-    section of mpi4py documentation. That said, it is highly encouraged to use your own MPI binaries as stated in the
-    `Using External MPI Libraries`_ section of the conda-forge documentation in order to get ultimate performance.
+    By default, mapping ``unidist-mpi`` installs a default MPI implementation, which comes with ``mpi4py`` package and is ready to use.
+    The conda dependency solver decides on which MPI implementation is to be installed. If you want to use a specific version of MPI,
+    you can install the core dependencies for MPI backend and the specific version of MPI as ``conda install unidist-mpi <mpi>``
+    as shown in the installation_ page of ``mpi4py`` documentation. That said, it is highly encouraged to use your own MPI binaries
+    as stated in the `Using External MPI Libraries`_ section of the conda-forge documentation in order to get ultimate performance.
 
 Using intel channel
 """""""""""""""""""

--- a/docs/optimization_notes/mpi.rst
+++ b/docs/optimization_notes/mpi.rst
@@ -18,7 +18,7 @@ Building MPI from source
 In `Building MPI from source`_ section of ``mpi4py`` documentation you can find executive instructions
 for building some of the open-source MPI implementations out there with support for shared/dynamic libraries on POSIX environments.
 
-After you install a working MPI implementation, you will have to first adapt your ``PATH`` environment variable
+Once you have a working MPI implementation, you will have to adapt your ``PATH`` environment variable
 to use the installed MPI version.
 
 .. code-block:: bash

--- a/docs/optimization_notes/mpi.rst
+++ b/docs/optimization_notes/mpi.rst
@@ -9,155 +9,35 @@ MPI backend
 We highly encourage to use external (either custom-built or system-provided) MPI installations
 in production scenarious to get ultimate performance.
 
-Open MPI
---------
+Open Source MPI implementaions
+------------------------------
 
-From source
-"""""""""""
+Building MPI from source
+""""""""""""""""""""""""
 
-The following instructions will help you install Open MPI from source to use it as the unidist's backend.
+In `Building MPI from source`_ section of ``mpi4py`` documentation you can find executive instructions
+for building some of the open-source MPI implementations out there with support for shared/dynamic libraries on POSIX environments.
 
-1. Create a directory for compiling Open MPI and go into it. You can do this in a terminal by typing
-
-.. code-block:: bash
-
-  mkdir local
-  cd local
-
-2. Download ``openmpi-4.1.5.tar.bz2`` from http://www.open-mpi.org, e.g., using ``curl`` command
+After you install a working MPI implementation, you will have to first adapt your ``PATH`` environment variable
+to use the installed MPI version.
 
 .. code-block:: bash
 
-  curl -O https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.bz2
-
-Note that we use the specific version of Open MPI as an example. You can install any version you want.
-
-3. Extract the package using
-
-.. code-block:: bash
-
-  tar -jxf openmpi-4.1.5.tar.bz2
-
-4. Go into the source directory
-
-.. code-block:: bash
-
-  cd openmpi-4.1.5
-
-5. Configure, compile and install by executing the following commands
-
-.. code-block:: bash
-
-  ./configure --prefix=path/to/local/<openmpi>
-  make all
-  make install
-
-This will install Open MPI in ``local/openmpi`` directory. You can speed up
-the compilation by replacing the ``make all`` command with ``make -j4 all``
-(this will compile using 4 cores).
-
-6. Install ``unidist`` and the required dependencies for the MPI backend
-
-To use the installed Open MPI you will have to first adapt your ``PATH`` environment variable.
-
-.. code-block:: bash
-
-  export PATH=path/to/local/openmpi/bin:$PATH
+  export PATH=path/to/mpi/bin:$PATH
 
 Then, you can install ``unidist`` and the required dependencies for the MPI backend.
 
 .. code-block:: bash
 
-  pip install mpi4py
-  pip install msgpack
-  pip install unidist
+  pip install unidist[mpi]
 
-Now you can use unidist on MPI backend using Open MPI implementaion.
+Now you can use unidist on MPI backend using the installed MPI implementaion.
 
-7. Remove the temporary directories (optional):
+Proprietary MPI implementations
+-------------------------------
 
-.. code-block:: bash
-
-  rm path/to/local/openmpi-4.1.5.tar.bz2
-  rm -rf path/to/local/openmpi-4.1.5
-
-MPICH
------
-
-From source
-"""""""""""
-
-The following instructions will help you install MPICH from source to use it as the unidist's backend.
-
-1. Create a directory for compiling MPICH and go into it. You can do this in a terminal by typing
-
-.. code-block:: bash
-
-  mkdir local
-  cd local
-
-2. Download ``mpich-4.1.1.tar.gz`` from https://www.mpich.org, e.g., using ``curl`` command
-
-.. code-block:: bash
-
-  curl -O https://www.mpich.org/static/downloads/4.1.1/mpich-4.1.1.tar.gz
-
-Note that we use the specific version of MPICH as an example. You can install any version you want.
-
-3. Extract the package using
-
-.. code-block:: bash
-
-  tar -xzvf mpich-4.1.1.tar.gz
-
-4. Go into the source directory
-
-.. code-block:: bash
-
-  cd mpich-4.1.1
-
-5. Configure, compile and install by executing the following commands
-
-.. code-block:: bash
-
-  ./configure --prefix=path/to/local/<mpich>
-  make all
-  make install
-
-This will install Open MPI in ``local/mpich`` directory. You can speed up
-the compilation by replacing the ``make all`` command with ``make -j4 all``
-(this will compile using 4 cores).
-
-6. Install ``unidist`` and the required dependencies for the MPI backend
-
-To use the installed MPICH you will have to first adapt your ``PATH`` environment variable.
-
-.. code-block:: bash
-
-  export PATH=path/to/local/mpich/bin:$PATH
-
-Then, you can install ``unidist`` and the required dependencies for the MPI backend.
-
-.. code-block:: bash
-
-  pip install mpi4py
-  pip install msgpack
-  pip install unidist
-
-Now you can use unidist on MPI backend using MPICH implementaion.
-
-7. Remove the temporary directories (optional):
-
-.. code-block:: bash
-
-  rm path/to/local/mpich-4.1.1.tar.gz
-  rm -rf path/to/local/mpich-4.1.1
-
-Intel MPI
----------
-
-From Intel oneAPI HPC Toolkit
-"""""""""""""""""""""""""""""
+Intel MPI From Intel oneAPI HPC Toolkit
+"""""""""""""""""""""""""""""""""""""""
 
 The following instructions will help you install Intel MPI from `Intel oneAPI HPC Toolkit`_ to use it as the unidist's backend.
 We will use an offline installer an an example but you are free to use other installation options.
@@ -197,9 +77,7 @@ During installation process you can choose a directory in which the toolkit shou
 
 .. code-block:: bash
 
-  pip install mpi4py
-  pip install msgpack
-  pip install unidist
+  pip install unidist[mpi]
 
 Now you can use unidist on MPI backend using Intel MPI implementaion.
 
@@ -210,3 +88,4 @@ Now you can use unidist on MPI backend using Intel MPI implementaion.
   rm l_HPCKit_p_2023.1.0.46346_offline.sh
 
 .. _`Intel oneAPI HPC Toolkit`: https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html
+.. _`Building MPI from source`: https://mpi4py.readthedocs.io/en/latest/appendix.html#building-mpi-from-sources

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cloudpickle
 Cython
 dask[complete]>=2.22.0
 distributed>=2.22.0
-mpi4py-mpich
+mpi4py>=3.0.3
 msgpack>=1.0.0
 # https://github.com/modin-project/unidist/issues/324
 pydantic<2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import versioneer
 # https://github.com/modin-project/unidist/issues/324
 ray_deps = ["ray[default]>=1.13.0", "pydantic<2"]
 dask_deps = ["dask[complete]>=2.22.0", "distributed>=2.22.0"]
-mpi_deps = ["mpi4py-mpich", "msgpack>=1.0.0"]
+mpi_deps = ["mpi4py>=3.0.3", "msgpack>=1.0.0"]
 if sys.version_info[1] < 8:
     mpi_deps += "pickle5"
 all_deps = ray_deps + dask_deps + mpi_deps


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #347  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
