### PR TITLE
FIX-#361: Fix warnings "autodoc: failed to import class ..."

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,13 @@ build:
     # We use mambaforge to install packages from conda-forge below
     python: "mambaforge-22.9"
 
+# We install unidist as a package to make C++ extensions available
+# for correct module imports when building the documentation.
+python:
+  install:
+    - method: pip
+      path: .
+
 sphinx:
    configuration: docs/conf.py
    # TODO: Fix #156 and set to true


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #361  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
