### PR TITLE
FIX-#371: Fix check for out of bounds reserved memory in shared storage

### DIFF
--- a/unidist/core/backends/mpi/core/shared_object_store.py
+++ b/unidist/core/backends/mpi/core/shared_object_store.py
@@ -431,18 +431,17 @@ class SharedObjectStore:
         for i, raw_buffer in enumerate(raw_buffers):
             raw_buffer_first_index = last_prev_index
             raw_buffer_len = len(raw_buffer)
-            raw_buffer_last_index = raw_buffer_first_index + len(raw_buffer)
-            if s_data_last_index > last_index:
+            last_prev_index = raw_buffer_first_index + len(raw_buffer)
+            if last_prev_index > last_index:
                 raise ValueError(f"Not enough shared space for {i} raw_buffer")
 
             parallel_memcopy(
                 raw_buffer,
-                self.shared_buffer[raw_buffer_first_index:raw_buffer_last_index],
+                self.shared_buffer[raw_buffer_first_index:last_prev_index],
                 6,
             )
 
             buffer_lens.append(raw_buffer_len)
-            last_prev_index = raw_buffer_last_index
 
         self.logger.debug(
             f"Rank {communication.MPIState.get_instance().global_rank}: PUT {data_id} from {first_index} to {last_prev_index}. Service index: {service_index}"
@@ -640,11 +639,11 @@ class SharedObjectStore:
                 self.service_shared_buffer[service_index + self.FIRST_DATA_INDEX] = -1
                 self.service_shared_buffer[service_index + self.REFERENCES_NUMBER] = -1
                 self.logger.debug(
-                    f"Rank {communication.MPIState.get_instance().global_rank}: Clear {old_data_id}. Service index: {service_index} First index: {old_first_index} References number: {old_references_number}"
+                    f"Rank {communication.MPIState.get_instance().global_rank}: Clear {data_id}. Service index: {service_index} First index: {old_first_index} References number: {old_references_number}"
                 )
             else:
                 self.logger.debug(
-                    f"Rank {communication.MPIState.get_instance().global_rank}: Did not clear {old_data_id}, because there are was written another data_id: Data_ID(rank_{old_worker_id}_id_{old_data_id})"
+                    f"Rank {communication.MPIState.get_instance().global_rank}: Did not clear {data_id}, because there are was written another data_id: Data_ID(rank_{old_worker_id}_id_{old_data_id})"
                 )
                 self.logger.debug(
                     f"Service index: {service_index} First index: {old_first_index} References number: {old_references_number}"


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #371 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
