### PR TITLE
FIX-#375: Fix running an MPI cluster without using shared memory

### DIFF
--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -130,7 +130,7 @@ class MPIState:
         if common.is_shared_memory_supported():
             self.monitor_processes = []
             for host in self.topology:
-                if len(self.topology[host]) > 2:
+                if len(self.topology[host]) >= 2:
                     self.monitor_processes.append(self.topology[host][MPIRank.MONITOR])
                 elif self.is_root_process():
                     raise ValueError(


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #375  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
