### PR TITLE
FIX-#337: Fix MpiHosts parameter usage

### DIFF
--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -70,7 +70,7 @@ Refer to ``Using intel channel`` section of :doc:`Installation </installation>` 
 SPMD model
 ----------
 
-First of all, to run unidist on MPI in a single node using `SPMD model <https://en.wikipedia.org/wiki/Single_program,_multiple_data>`_,
+First of all, to run unidist on MPI in a single node using `SPMD model`_,
 you should set the ``UNIDIST_IS_MPI_SPAWN_WORKERS`` environment variable to ``False``:
 
 .. code-block:: bash
@@ -122,9 +122,8 @@ Running is almost the same as in a single node, but, in addition,
 you should use the appropriate parameter for ``mpiexec``.
 This parameter differs depending on the MPI implementation used.
 
-* For Intel MPI or MPICH: ``-hosts host1,host2``. You can also see 
-`Controlling Process Placement with the Intel® MPI Library <https://www.intel.com/content/www/us/en/developer/articles/technical/controlling-process-placement-with-the-intel-mpi-library.html>`_ 
-or `MPICH wiki <https://github.com/pmodels/mpich/blob/main/doc/wiki/how_to/Using_the_Hydra_Process_Manager.md>`_ for deeper customization.
+* For Intel MPI or MPICH: ``-hosts host1,host2``. You can also see `Controlling Process Placement with the Intel® MPI Library`_ 
+or `MPICH wiki`_ for deeper customization.
 
 * For OpenMPI: ``-host host1:n1,...,hostM:nM``
 where n1, ..., nM is the number of processes on each node, including Unidist service processes (root and one or some monitors).
@@ -168,4 +167,9 @@ Running is the same as in a single node.
 
 .. code-block:: bash
 
-    ssh host ENV_VARIABLE=value "source /PATH_TO_CONDA/activate CONDA_ENV; cd $PWD; python script.py"
+    ssh host ENV_VARIABLE=value "source $CONDA_PATH/bin/activate $CONDA_ENV; cd $PWD; python script.py"
+
+
+.. _`SPMD model`: https://en.wikipedia.org/wiki/Single_program,_multiple_data
+.. _`Controlling Process Placement with the Intel® MPI Library`: https://www.intel.com/content/www/us/en/developer/articles/technical/controlling-process-placement-with-the-intel-mpi-library.html
+.. _`MPICH wiki`: https://github.com/pmodels/mpich/blob/main/doc/wiki/how_to/Using_the_Hydra_Process_Manager.md

--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -110,7 +110,7 @@ When initializing unidist this execution model gets transformed to Controller/Wo
 Unidist on MPI cluster
 """"""""""""""""""""""
 
-Regardless of the chosen usage model (SPMD model or Controller/Worker model),
+Regardless of the chosen execution model (SPMD or Controller/Worker),
 there are two options for running on a cluster.
 
 Running with ``mpiexec`` command
@@ -127,14 +127,14 @@ This parameter differs depending on the MPI implementation used.
 or `MPICH wiki <https://github.com/pmodels/mpich/blob/main/doc/wiki/how_to/Using_the_Hydra_Process_Manager.md>`_ for deeper customization.
 
 * For OpenMPI: ``-host host1:n1,...,hostM:nM``
-where n1, ..., nM is the number of processes on each node, including system processes.
+where n1, ..., nM is the number of processes on each node, including Unidist service processes (root and one or some monitors).
 You can also see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>`_ for deeper customization. 
-
 
 Running without ``mpiexec`` command
 -----------------------------------
 
-To run unidist on MPI in a cluster without the ``mpiexec`` command, you should specify hosts to run on.
+To run unidist on MPI in a cluster without ``mpiexec`` command,
+you should specify MPI hosts to run on using unidist configuration settings.
 
 There are two ways to specify MPI hosts to run on.
 First, by setting the ``UNIDIST_MPI_HOSTS`` environment variable:
@@ -163,7 +163,7 @@ Running is the same as in a single node.
 
 .. note::
     Root proccess will allways be executed locally and other proccesses will be spawned in order on the specified hosts.
-    If you want to run root proccess on anoother host, you should use `ssh host` before the command and carefully check that the environment is correct. 
+    If you want to run root process on a remote host, you should use `ssh host` before the command and carefully check that the environment is correct. 
     You can set some variables in ssh command or activate the conda envirenment right before running the Python script:
 
 .. code-block:: bash

--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -110,13 +110,29 @@ When initializing unidist this execution model gets transformed to Controller/Wo
 Unidist on MPI cluster
 """"""""""""""""""""""
 
-In order to run unidist on MPI in a cluster, there are two options.
+Regardless of the chosen usage model (SPMD model or Controller/Worker model), there are two options for running on a cluster
 
-Controller/Worker model
------------------------
+Running with `mpiexec` command
+------------------------------
 
-This execution model is similar to ones other execution backends use.
-In order to run unidist on MPI in a cluster you should specify hosts to run on.
+This option is the most preferred and customizable.
+
+Running is almost the same as in a single node, but you should use the appropriate parameter for "mpiexec". This parameter differs depending on the mpi implementation used.
+
+For Intel MPI or MPICH: `-hosts host1,host2`. You also can see 
+`Controlling Process Placement with the Intel® MPI Library <https://www.intel.com/content/www/us/en/developer/articles/technical/controlling-process-placement-with-the-intel-mpi-library.html>` 
+for more deeper customize. 
+
+For OpenMPi: `-host host1:n1,...,hostM:nM`
+where n1, ..., nM is the number of processes on each node, including system processes.
+You also can see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>` for more deeper customize. 
+
+
+Running without 'mpiexec' command
+---------------------------------
+
+To run the unidist on a cluster without the `mpiexec` command, you should specify hosts to run on.
+
 There are two ways to specify MPI hosts to run on.
 First, by setting the ``UNIDIST_MPI_HOSTS`` environment variable:
 
@@ -142,42 +158,14 @@ Second, by setting the configuration value associated with the environment varia
 
 Running is the same as in a single node.
 
-SPMD model
-""""""""""
-
-First of all, to run unidist on MPI in a cluster using `SPMD model <https://en.wikipedia.org/wiki/Single_program,_multiple_data>`_,
-you should set the ``UNIDIST_IS_MPI_SPAWN_WORKERS`` environment variable to ``False``:
-
-.. code-block:: bash
-
-    $ export UNIDIST_IS_MPI_SPAWN_WORKERS=False
-
-.. code-block:: python
-
-    import os
-
-    os.environ["UNIDIST_IS_MPI_SPAWN_WORKERS"] = "False"
-
-or set the associated configuration value:
-
-.. code-block:: python
-
-    from unidist.config import IsMpiSpawnWorkers
-
-    IsMpiSpawnWorkers.put(False)
-
-This will enable unidist not to spawn MPI processes dynamically because the user himself spawns the processes.
-
-Then, you should also use ``mpiexec`` command and specify both hosts and a number of workers to spawn on each node.
+.. note::
+    Root proccess will allways be executed locally and other proccesses will be spawned in order on the specified hosts.
+    If you want to run root proccess on anoother host you should use `ssh host` before your command and thoroughly check that environment will be correct. 
+    You can set some variables into ssh or activate conda envirenment before running python script.
+    
+    If you want to start a root process on another host, you should use `ssh host` before the command and carefully check that the environment is correct. 
+    You can set some variables in ssh command or activate the conda environment right before running the Python script:
 
 .. code-block:: bash
 
-    $ mpiexec -host host1:n1,...,hostM:nM python script.py
-
-When initializing unidist this execution model gets transformed to Controller/Worker model.
-
-.. note:: 
-    Note that the process with rank 0 devotes for the controller (master) process you interact with,
-    the process with rank 1 devotes for the monitor process unidist on MPI uses for tracking executed tasks.
-    So the processes with ranks 2 to N devote for worker processes where computation will be executed.
-    If you right away use Controller/Worker model to run unidist on MPI, this happens transparently.
+    ssh host ENV_VARIABLE=value "source /PATH_TO_CONDA/activate CONDA_ENV; cd $PWD; python script.py"

--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -65,7 +65,8 @@ without using ``mpiexec`` command so you can run unidist on Intel MPI just with:
 
     $ python script.py
 
-Refer to ``Using intel channel`` section of :doc:`Installation </installation>` page on how to install Intel MPI implementation to use it with unidist.
+Refer to ``Using intel channel`` section of :doc:`Installation </installation>` page on
+how to install Intel MPI implementation to use it with unidist.
 
 SPMD model
 ----------
@@ -102,7 +103,7 @@ Then, you should also use ``mpiexec`` command and specify a number of workers to
 When initializing unidist this execution model gets transformed to Controller/Worker model.
 
 .. note:: 
-    Note that the process with rank 0 devotes for the controller (master) process you interact with,
+    Note that the process with rank 0 devotes for the controller (root) process you interact with,
     the process with rank 1 devotes for the monitor process unidist on MPI uses for tracking executed tasks.
     So the processes with ranks 2 to N devote for worker processes where computation will be executed.
     If you right away use Controller/Worker model to run unidist on MPI, this happens transparently.
@@ -141,33 +142,33 @@ Second, by setting the configuration value associated with the environment varia
 
     MpiHosts.put("host1,...,hostN")  # unidist will use the hosts to run on
 
-
-Then, if you running without ``mpiexec`` command it is enough and the running is the same as in a single node.
+If you're running a program without ``mpiexec`` command, no further action required to run on specified MPI hosts.
 
 .. note::
-    Root proccess will allways be executed locally and other proccesses will be spawned in order on the specified hosts.
-    If you want to run root process on a remote host, you should use `ssh host` before the command and carefully check that the environment is correct. 
-    You can set some variables in ssh command or activate the conda envirenment right before running the Python script:
+    Root proccess will always be executed locally and other proccesses will be spawned in order on the specified hosts.
+    If you want to run root process on a remote host, you should use ``ssh host`` before the command and
+    carefully check that the environment is correct. You can set some variables in ssh command or
+    activate the conda envirenment right before running the Python script:
 
 .. code-block:: bash
 
     ssh host ENV_VARIABLE=value "source $CONDA_PATH/bin/activate $CONDA_ENV; cd $PWD; python script.py"
 
-Running is almost the same as in a single node, but, in addition,
-you should use the appropriate parameter for ``mpiexec``.
+If you're running a program with ``mpiexec`` command, running is almost the same as in a single node,
+but, in addition, you should use the appropriate parameter for ``mpiexec``.
 This parameter differs depending on the MPI implementation used.
 
-* For Intel MPI or MPICH: ``-hosts host1,host2``.
+* For Intel MPI or MPICH: ``-hosts host1,...,hostN``.
   You can also see `Controlling Process Placement with the Intel® MPI Library`_  or
   `MPICH wiki`_ for deeper customization.
-* For OpenMPI: ``-host host1:n1,...,hostM:nM``, where n1, ..., nM is the number of processes on each node,
+* For OpenMPI: ``-host host1:m1,...,hostN:mN``, where m1, ..., mN is the number of processes on each node,
   including unidist service processes (root and monitor(s)).
-  You can also see `Scheduling processes across hosts with OpenMPI Library`_ for deeper customization. 
+  You can also see `Scheduling processes across hosts with OpenMPI Library`_ for deeper customization.
 
 SPMD model
 """"""""""
 
-First of all, to run unidist on MPI in a cluster using `SPMD model <https://en.wikipedia.org/wiki/Single_program,_multiple_data>`_,
+First of all, to run unidist on MPI in a cluster using `SPMD model`_,
 you should set the ``UNIDIST_IS_MPI_SPAWN_WORKERS`` environment variable to ``False``:
 
 .. code-block:: bash
@@ -193,15 +194,15 @@ This will enable unidist not to spawn MPI processes dynamically because the user
 Then, you should use the appropriate parameter for ``mpiexec``.
 This parameter differs depending on the MPI implementation used.
 
-* For Intel MPI or MPICH: ``-hosts host1,...,hostM``. You can also see `Controlling Process Placement with the Intel® MPI Library`_ 
-or `MPICH wiki`_ for deeper customization.
-
-* For OpenMPI: ``-host host1:n1,...,hostM:nM``
-where n1, ..., nM is the number of processes on each node, including Unidist service processes (root and one or some monitors).
-You can also see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>`_ for deeper customization. 
+* For Intel MPI or MPICH: ``-hosts host1,...,hostN``.
+  You can also see `Controlling Process Placement with the Intel® MPI Library`_  or
+  `MPICH wiki`_ for deeper customization.
+* For OpenMPI: ``-host host1:m1,...,hostN:mN``, where m1, ..., mN is the number of processes on each node,
+  including unidist service processes (root and monitor(s)).
+  You can also see `Scheduling processes across hosts with OpenMPI Library`_ for deeper customization.
 
 .. note:: 
-    Note that the process with rank 0 devotes for the controller (master) process you interact with,
+    Note that the process with rank 0 devotes for the controller (root) process you interact with,
     the process with rank 1 devotes for the monitor process unidist on MPI uses for tracking executed tasks.
     So the processes with ranks 2 to N devote for worker processes where computation will be executed.
     If you right away use Controller/Worker model to run unidist on MPI, this happens transparently.

--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -110,28 +110,31 @@ When initializing unidist this execution model gets transformed to Controller/Wo
 Unidist on MPI cluster
 """"""""""""""""""""""
 
-Regardless of the chosen usage model (SPMD model or Controller/Worker model), there are two options for running on a cluster
+Regardless of the chosen usage model (SPMD model or Controller/Worker model),
+there are two options for running on a cluster.
 
-Running with `mpiexec` command
-------------------------------
+Running with ``mpiexec`` command
+--------------------------------
 
 This option is the most preferred and customizable.
 
-Running is almost the same as in a single node, but you should use the appropriate parameter for "mpiexec". This parameter differs depending on the mpi implementation used.
+Running is almost the same as in a single node, but, in addition,
+you should use the appropriate parameter for ``mpiexec``.
+This parameter differs depending on the MPI implementation used.
 
-For Intel MPI or MPICH: `-hosts host1,host2`. You also can see 
+* For Intel MPI or MPICH: ``-hosts host1,host2``. You can also see 
 `Controlling Process Placement with the Intel® MPI Library <https://www.intel.com/content/www/us/en/developer/articles/technical/controlling-process-placement-with-the-intel-mpi-library.html>` 
-for more deeper customize. 
+for deeper customization.
 
-For OpenMPi: `-host host1:n1,...,hostM:nM`
+* For OpenMPI: ``-host host1:n1,...,hostM:nM``
 where n1, ..., nM is the number of processes on each node, including system processes.
-You also can see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>` for more deeper customize. 
+You can also see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>` for deeper customization. 
 
 
-Running without 'mpiexec' command
----------------------------------
+Running without ``mpiexec`` command
+-----------------------------------
 
-To run the unidist on a cluster without the `mpiexec` command, you should specify hosts to run on.
+To run unidist on MPI in a cluster without the ``mpiexec`` command, you should specify hosts to run on.
 
 There are two ways to specify MPI hosts to run on.
 First, by setting the ``UNIDIST_MPI_HOSTS`` environment variable:

--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -123,12 +123,12 @@ you should use the appropriate parameter for ``mpiexec``.
 This parameter differs depending on the MPI implementation used.
 
 * For Intel MPI or MPICH: ``-hosts host1,host2``. You can also see 
-`Controlling Process Placement with the Intel® MPI Library <https://www.intel.com/content/www/us/en/developer/articles/technical/controlling-process-placement-with-the-intel-mpi-library.html>` 
-for deeper customization.
+`Controlling Process Placement with the Intel® MPI Library <https://www.intel.com/content/www/us/en/developer/articles/technical/controlling-process-placement-with-the-intel-mpi-library.html>`_ 
+or `MPICH wiki <https://github.com/pmodels/mpich/blob/main/doc/wiki/how_to/Using_the_Hydra_Process_Manager.md>`_ for deeper customization.
 
 * For OpenMPI: ``-host host1:n1,...,hostM:nM``
 where n1, ..., nM is the number of processes on each node, including system processes.
-You can also see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>` for deeper customization. 
+You can also see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>`_ for deeper customization. 
 
 
 Running without ``mpiexec`` command
@@ -163,11 +163,8 @@ Running is the same as in a single node.
 
 .. note::
     Root proccess will allways be executed locally and other proccesses will be spawned in order on the specified hosts.
-    If you want to run root proccess on anoother host you should use `ssh host` before your command and thoroughly check that environment will be correct. 
-    You can set some variables into ssh or activate conda envirenment before running python script.
-    
-    If you want to start a root process on another host, you should use `ssh host` before the command and carefully check that the environment is correct. 
-    You can set some variables in ssh command or activate the conda environment right before running the Python script:
+    If you want to run root proccess on anoother host, you should use `ssh host` before the command and carefully check that the environment is correct. 
+    You can set some variables in ssh command or activate the conda envirenment right before running the Python script:
 
 .. code-block:: bash
 

--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -50,7 +50,7 @@ Controller/Worker model
 -----------------------
 
 This execution model is similar to ones other execution backends use.
-To run unidist on MPI in a single node using Controller/Worker model you should use ``mpiexec -n 1 python <script.py>`` command.
+To run unidist on MPI in a single node using Controller/Worker model you should use ``mpiexec`` command.
 
 .. code-block:: bash
 
@@ -117,7 +117,7 @@ Controller/Worker model
 -----------------------
 
 This execution model is similar to ones other execution backends use.
-In order to run unidist on MPI in a cluster you should specify hosts to run on.
+To run unidist on MPI in a cluster using Controller/Worker model you should specify hosts to run on.
 There are two ways to specify MPI hosts to run on.
 
 First, by setting the ``UNIDIST_MPI_HOSTS`` environment variable:
@@ -142,7 +142,7 @@ Second, by setting the configuration value associated with the environment varia
 
     MpiHosts.put("host1,...,hostN")  # unidist will use the hosts to run on
 
-If you're running a program without ``mpiexec`` command, no further action required to run on specified MPI hosts.
+If you're running a program without ``mpiexec`` command, no further action required to run on the specified MPI hosts.
 
 .. note::
     Root proccess will always be executed locally and other proccesses will be spawned in order on the specified hosts.
@@ -161,7 +161,7 @@ This parameter differs depending on the MPI implementation used.
 * For Intel MPI or MPICH: ``-hosts host1,...,hostN``.
   You can also see `Controlling Process Placement with the Intel® MPI Library`_  or
   `MPICH wiki`_ for deeper customization.
-* For OpenMPI: ``-host host1:m1,...,hostN:mN``, where m1, ..., mN is the number of processes on each node,
+* For OpenMPI: ``-host host1:m1,...,hostN:mN``, where ``m1, ..., mN`` is the number of processes on each node,
   including unidist service processes (root and monitor(s)).
   You can also see `Scheduling processes across hosts with OpenMPI Library`_ for deeper customization.
 
@@ -197,7 +197,7 @@ This parameter differs depending on the MPI implementation used.
 * For Intel MPI or MPICH: ``-hosts host1,...,hostN``.
   You can also see `Controlling Process Placement with the Intel® MPI Library`_  or
   `MPICH wiki`_ for deeper customization.
-* For OpenMPI: ``-host host1:m1,...,hostN:mN``, where m1, ..., mN is the number of processes on each node,
+* For OpenMPI: ``-host host1:m1,...,hostN:mN``, where ``m1, ..., mN`` is the number of processes on each node,
   including unidist service processes (root and monitor(s)).
   You can also see `Scheduling processes across hosts with OpenMPI Library`_ for deeper customization.
 

--- a/docs/using_unidist/unidist_on_mpi.rst
+++ b/docs/using_unidist/unidist_on_mpi.rst
@@ -58,7 +58,7 @@ To run unidist on MPI in a single node using Controller/Worker model you should 
 
 MPI worker processes will be spawned dynamically by unidist.
 
-It is worth noting that `Intel MPI implementation <https://anaconda.org/intel/mpi4py>`_ supports the ability of spawning MPI processes
+It is worth noting that some MPI implementations, e.g., `Intel MPI implementation`_, support the ability of spawning MPI processes
 without using ``mpiexec`` command so you can run unidist on Intel MPI just with:
 
 .. code-block:: bash
@@ -122,12 +122,12 @@ Running is almost the same as in a single node, but, in addition,
 you should use the appropriate parameter for ``mpiexec``.
 This parameter differs depending on the MPI implementation used.
 
-* For Intel MPI or MPICH: ``-hosts host1,host2``. You can also see `Controlling Process Placement with the Intel® MPI Library`_ 
-or `MPICH wiki`_ for deeper customization.
-
-* For OpenMPI: ``-host host1:n1,...,hostM:nM``
-where n1, ..., nM is the number of processes on each node, including Unidist service processes (root and one or some monitors).
-You can also see `Scheduling processes across hosts with OpenMPI Library <https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html>`_ for deeper customization. 
+* For Intel MPI or MPICH: ``-hosts host1,host2``.
+  You can also see `Controlling Process Placement with the Intel® MPI Library`_  or
+  `MPICH wiki`_ for deeper customization.
+* For OpenMPI: ``-host host1:n1,...,hostM:nM``, where n1, ..., nM is the number of processes on each node,
+  including unidist service processes (root and monitor(s)).
+  You can also see `Scheduling processes across hosts with OpenMPI Library`_ for deeper customization. 
 
 Running without ``mpiexec`` command
 -----------------------------------
@@ -171,5 +171,7 @@ Running is the same as in a single node.
 
 
 .. _`SPMD model`: https://en.wikipedia.org/wiki/Single_program,_multiple_data
+.. _`Intel MPI implementation`: https://anaconda.org/intel/mpi4py
 .. _`Controlling Process Placement with the Intel® MPI Library`: https://www.intel.com/content/www/us/en/developer/articles/technical/controlling-process-placement-with-the-intel-mpi-library.html
 .. _`MPICH wiki`: https://github.com/pmodels/mpich/blob/main/doc/wiki/how_to/Using_the_Hydra_Process_Manager.md
+.. _`Scheduling processes across hosts with OpenMPI Library`: https://docs.open-mpi.org/en/v5.0.x/launching-apps/scheduling.html

--- a/unidist/config/backends/mpi/envvars.py
+++ b/unidist/config/backends/mpi/envvars.py
@@ -15,7 +15,13 @@ class IsMpiSpawnWorkers(EnvironmentVariable, type=bool):
 
 
 class MpiHosts(EnvironmentVariable, type=ExactStr):
-    """MPI hosts to run unidist on."""
+    """
+    MPI hosts to run unidist on.
+
+    Notes
+    -----
+    This variable is only used without mpiexec.
+    """
 
     varname = "UNIDIST_MPI_HOSTS"
 

--- a/unidist/config/backends/mpi/envvars.py
+++ b/unidist/config/backends/mpi/envvars.py
@@ -20,7 +20,7 @@ class MpiHosts(EnvironmentVariable, type=ExactStr):
 
     Notes
     -----
-    This variable is only used if a program is run without mpiexec.
+    This variable is only used if a program is run in Controller/Worker model.
     """
 
     varname = "UNIDIST_MPI_HOSTS"

--- a/unidist/config/backends/mpi/envvars.py
+++ b/unidist/config/backends/mpi/envvars.py
@@ -20,7 +20,7 @@ class MpiHosts(EnvironmentVariable, type=ExactStr):
 
     Notes
     -----
-    This variable is only used without mpiexec.
+    This variable is only used if a program is run without mpiexec.
     """
 
     varname = "UNIDIST_MPI_HOSTS"

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -503,7 +503,8 @@ def is_run_with_mpiexec():
     bool
         True or False.
     """
-    if "Intel" in MPI.Get_library_version() and os.getenv("PMI_RANK") is None:
+    lib_version = MPI.Get_library_version()
+    if "Intel" in lib_version and os.getenv("PMI_RANK") is None:
         return False
 
     if "MPICH" in MPI.Get_library_version() and os.getenv("PMI_RANK") is None:
@@ -516,6 +517,6 @@ def is_run_with_mpiexec():
         return False
 
     # The latest MSMPI does not support running without mpiexec.
-    # The other MPI library hasn't been checked.
+    # Other MPI libraries haven't been checked.
 
     return True

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -4,7 +4,6 @@
 
 """Common classes and utilities."""
 
-import os
 import logging
 import inspect
 import weakref
@@ -491,28 +490,4 @@ def is_shared_memory_supported():
     ):
         return False
 
-    return True
-
-
-def is_run_with_mpiexec():
-    """
-    Check if the unidist was run using `mpiexec` command.
-
-    Returns
-    -------
-    bool
-        True or False.
-    """
-    lib_version = MPI.Get_library_version()
-    if "Intel" in lib_version and os.getenv("PMI_RANK") is None:
-        return False
-
-    if "MPICH" in lib_version and os.getenv("PMI_RANK") is None:
-        return False
-
-    if "Open MPI" in lib_version and os.getenv("OMPI_COMM_WORLD_RANK") is None:
-        return False
-
-    # The latest MSMPI does not support running without mpiexec.
-    # Other MPI libraries haven't been checked.
     return True

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -507,16 +507,12 @@ def is_run_with_mpiexec():
     if "Intel" in lib_version and os.getenv("PMI_RANK") is None:
         return False
 
-    if "MPICH" in MPI.Get_library_version() and os.getenv("PMI_RANK") is None:
+    if "MPICH" in lib_version and os.getenv("PMI_RANK") is None:
         return False
 
-    if (
-        "Open MPI" in MPI.Get_library_version()
-        and os.getenv("OMPI_COMM_WORLD_RANK") is None
-    ):
+    if "Open MPI" in lib_version and os.getenv("OMPI_COMM_WORLD_RANK") is None:
         return False
 
     # The latest MSMPI does not support running without mpiexec.
     # Other MPI libraries haven't been checked.
-
     return True

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -494,9 +494,9 @@ def is_shared_memory_supported():
     return True
 
 
-def is_runned_by_mpiexec():
+def is_run_with_mpiexec():
     """
-    Check if the unidist was running using `mpiexec` command.
+    Check if the unidist was run using `mpiexec` command.
 
     Returns
     -------
@@ -515,7 +515,7 @@ def is_runned_by_mpiexec():
     ):
         return False
 
-    # The lastest MS MPI does not support running without mpiexec.
+    # The latest MSMPI does not support running without mpiexec.
     # The other MPI library hasn't been checked.
 
     return True

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -4,6 +4,7 @@
 
 """Common classes and utilities."""
 
+import os
 import logging
 import inspect
 import weakref
@@ -489,5 +490,32 @@ def is_shared_memory_supported():
         and not check_mpich_version("4.2.0")
     ):
         return False
+
+    return True
+
+
+def is_runned_by_mpiexec():
+    """
+    Check if the unidist was running using `mpiexec` command.
+
+    Returns
+    -------
+    bool
+        True or False.
+    """
+    if "Intel" in MPI.Get_library_version() and os.getenv("PMI_RANK") is None:
+        return False
+
+    if "MPICH" in MPI.Get_library_version() and os.getenv("PMI_RANK") is None:
+        return False
+
+    if (
+        "Open MPI" in MPI.Get_library_version()
+        and os.getenv("OMPI_COMM_WORLD_RANK") is None
+    ):
+        return False
+
+    # The lastest MS MPI does not support running without mpiexec.
+    # The other MPI library hasn't been checked.
 
     return True

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -132,7 +132,7 @@ class MPIState:
 
         mpi_hosts = MpiHosts.get()
         if mpi_hosts is not None:
-            host_list = mpi_hosts.split(",") if mpi_hosts is not None else ["localhost"]
+            host_list = mpi_hosts.split(",")
             host_count = len(host_list)
 
             # check running hosts

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -7,6 +7,7 @@
 from collections import defaultdict
 import socket
 import time
+import warnings
 
 try:
     import mpi4py
@@ -131,14 +132,14 @@ class MPIState:
             self.host_by_rank[global_rank] = host
 
         mpi_hosts = MpiHosts.get()
-        if mpi_hosts is not None and is_run_with_mpiexec():
+        if mpi_hosts is not None and not common.is_run_with_mpiexec():
             host_list = mpi_hosts.split(",")
             host_count = len(host_list)
 
             # check running hosts
             if self.is_root_process() and len(self.topology.keys()) > host_count:
-                print(
-                    """WARNING: The number of running hosts is greater than that specified in the UNIDIST_MPI_HOSTS.
+                warnings.warn(
+                    """The number of running hosts is greater than that specified in the UNIDIST_MPI_HOSTS.
                     If you want to run the program on a host other than the local one, specify the appropriate parameter for `mpiexec`
                     (`--host` for OpenMPI or `--hosts` for other MPI implementations)
                 """
@@ -146,8 +147,8 @@ class MPIState:
 
             # check running hosts
             if self.is_root_process() and len(self.topology.keys()) < host_count:
-                print(
-                    "WARNING: The number of running hosts is less than that specified in the UNIDIST_MPI_HOSTS. Check the `mpiexec` option to distribute processes between hosts."
+                warnings.warn(
+                    "The number of running hosts is less than that specified in the UNIDIST_MPI_HOSTS. Check the `mpiexec` option to distribute processes between hosts."
                 )
 
         if common.is_shared_memory_supported():

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -131,7 +131,7 @@ class MPIState:
             self.host_by_rank[global_rank] = host
 
         mpi_hosts = MpiHosts.get()
-        if mpi_hosts is not None:
+        if mpi_hosts is not None and is_run_with_mpiexec():
             host_list = mpi_hosts.split(",")
             host_count = len(host_list)
 

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -23,7 +23,7 @@ from unidist.core.backends.mpi.core.serialization import (
     deserialize_complex_data,
 )
 import unidist.core.backends.mpi.core.common as common
-from unidist.config.backends.mpi.envvars import MpiHosts
+from unidist.config.backends.mpi.envvars import IsMpiSpawnWorkers, MpiHosts
 
 # TODO: Find a way to move this after all imports
 mpi4py.rc(recv_mprobe=False, initialize=False)
@@ -132,7 +132,7 @@ class MPIState:
             self.host_by_rank[global_rank] = host
 
         mpi_hosts = MpiHosts.get()
-        if mpi_hosts is not None and not common.is_run_with_mpiexec():
+        if mpi_hosts is not None and IsMpiSpawnWorkers.get():
             host_list = mpi_hosts.split(",")
             host_count = len(host_list)
 

--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -139,18 +139,15 @@ class MPIState:
             # check running hosts
             if self.is_root_process() and len(self.topology.keys()) > host_count:
                 warnings.warn(
-                    """The number of running hosts is greater than that specified in the UNIDIST_MPI_HOSTS.
-                    If you want to run the program on a host other than the local one, specify the appropriate parameter for `mpiexec`
-                    (`--host` for OpenMPI or `--hosts` for other MPI implementations)
-                """
+                    "The number of running hosts is greater than that specified in the UNIDIST_MPI_HOSTS. "
+                    + "If you want to run the program on a host other than the local one, specify the appropriate parameter for `mpiexec` "
+                    + "(`--host` for OpenMPI and `--hosts` for Intel MPI or MPICH)."
                 )
-
-            # check running hosts
             if self.is_root_process() and len(self.topology.keys()) < host_count:
                 warnings.warn(
-                    "The number of running hosts is less than that specified in the UNIDIST_MPI_HOSTS. Check the `mpiexec` option to distribute processes between hosts."
+                    "The number of running hosts is less than that specified in the UNIDIST_MPI_HOSTS. "
+                    + "Check the `mpiexec` option to distribute processes between hosts."
                 )
-
         if common.is_shared_memory_supported():
             self.monitor_processes = []
             for host in self.topology:

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -157,7 +157,7 @@ def init():
         # MpiHosts should only be used without mpiexec.
         if (
             MpiHosts.get_value_source() != ValueSource.DEFAULT
-            and not common.is_runned_by_mpiexec()
+            and not common.is_run_with_mpiexec()
         ):
             py_str += [f"cfg.MpiHosts.put('{MpiHosts.get()}')"]
         else:

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -9,7 +9,6 @@ import sys
 import atexit
 import signal
 import asyncio
-import warnings
 from collections import defaultdict
 
 try:
@@ -155,15 +154,8 @@ def init():
         ]
         if IsMpiSpawnWorkers.get_value_source() != ValueSource.DEFAULT:
             py_str += [f"cfg.IsMpiSpawnWorkers.put({IsMpiSpawnWorkers.get()})"]
-        # MpiHosts should only be used without mpiexec.
         if MpiHosts.get_value_source() != ValueSource.DEFAULT:
-            if common.is_run_with_mpiexec():
-                warnings.warn(
-                    "MpiHosts is not used when running a script using mpiexec. "
-                    + "Find out more about running unidist on MPI cluster in the unidist documentation."
-                )
-            else:
-                py_str += [f"cfg.MpiHosts.put('{MpiHosts.get()}')"]
+            py_str += [f"cfg.MpiHosts.put('{MpiHosts.get()}')"]
         if CpuCount.get_value_source() != ValueSource.DEFAULT:
             py_str += [f"cfg.CpuCount.put({CpuCount.get()})"]
         if MpiPickleThreshold.get_value_source() != ValueSource.DEFAULT:
@@ -197,6 +189,7 @@ def init():
         args += [py_str]
 
         cpu_count = CpuCount.get()
+        hosts = MpiHosts.get()
         info = MPI.Info.Create()
         lib_version = MPI.Get_library_version()
         if "Intel" in lib_version:
@@ -205,16 +198,17 @@ def init():
             # See more about Intel MPI environment variables in
             # https://www.intel.com/content/www/us/en/docs/mpi-library/developer-reference-linux/2021-8/other-environment-variables.html.
             os.environ["I_MPI_SPAWN"] = "1"
-        # +1 for just a single process monitor
-        nprocs_to_spawn = cpu_count + 1
-        hosts = MpiHosts.get()
-        if hosts is not None and not common.is_run_with_mpiexec():
-            host_list = hosts.split(",")
-            host_count = len(host_list)
-            if common.is_shared_memory_supported():
-                # +host_count to add monitor process on each host
-                nprocs_to_spawn = cpu_count + host_count
 
+        host_list = hosts.split(",") if hosts is not None else ["localhost"]
+        host_count = len(host_list)
+
+        if common.is_shared_memory_supported():
+            # +host_count to add monitor process on each host
+            nprocs_to_spawn = cpu_count + host_count
+        else:
+            # +1 for just a single process monitor
+            nprocs_to_spawn = cpu_count + 1
+        if host_count > 1:
             if "Open MPI" in lib_version:
                 # +1 to take into account the current root process
                 # to correctly allocate slots

--- a/unidist/core/backends/mpi/core/controller/api.py
+++ b/unidist/core/backends/mpi/core/controller/api.py
@@ -159,12 +159,11 @@ def init():
         if MpiHosts.get_value_source() != ValueSource.DEFAULT:
             if common.is_run_with_mpiexec():
                 warnings.warn(
-                    "MpiHosts is not used when running a script using mpiexec."
-                    + "Find out more about running Unidist on MPI cluster in the Unidist documentation."
+                    "MpiHosts is not used when running a script using mpiexec. "
+                    + "Find out more about running unidist on MPI cluster in the unidist documentation."
                 )
             else:
                 py_str += [f"cfg.MpiHosts.put('{MpiHosts.get()}')"]
-
         if CpuCount.get_value_source() != ValueSource.DEFAULT:
             py_str += [f"cfg.CpuCount.put({CpuCount.get()})"]
         if MpiPickleThreshold.get_value_source() != ValueSource.DEFAULT:
@@ -206,15 +205,12 @@ def init():
             # See more about Intel MPI environment variables in
             # https://www.intel.com/content/www/us/en/docs/mpi-library/developer-reference-linux/2021-8/other-environment-variables.html.
             os.environ["I_MPI_SPAWN"] = "1"
-
         # +1 for just a single process monitor
         nprocs_to_spawn = cpu_count + 1
-
         hosts = MpiHosts.get()
         if hosts is not None and not common.is_run_with_mpiexec():
             host_list = hosts.split(",")
             host_count = len(host_list)
-
             if common.is_shared_memory_supported():
                 # +host_count to add monitor process on each host
                 nprocs_to_spawn = cpu_count + host_count

--- a/unidist/core/backends/mpi/core/shared_object_store.py
+++ b/unidist/core/backends/mpi/core/shared_object_store.py
@@ -7,6 +7,7 @@
 import os
 import sys
 import time
+import warnings
 import psutil
 import weakref
 from array import array
@@ -137,7 +138,7 @@ class SharedObjectStore:
                 shm_stats = os.fstatvfs(shm_fd)
                 system_memory = shm_stats.f_bsize * shm_stats.f_bavail
                 if system_memory / (virtual_memory / 2) < 0.99:
-                    print(
+                    warnings.warn(
                         f"The size of /dev/shm is too small ({system_memory} bytes). The required size "
                         + f"at least half of RAM ({virtual_memory // 2} bytes). Please, delete files in /dev/shm or "
                         + "increase size of /dev/shm with --shm-size in Docker."


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #337  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
