### PR TITLE
FEAT-#386: Make MPI shared object store default option

### DIFF
--- a/unidist/config/backends/mpi/envvars.py
+++ b/unidist/config/backends/mpi/envvars.py
@@ -87,7 +87,7 @@ class MpiLog(EnvironmentVariable, type=bool):
 class MpiSharedObjectStore(EnvironmentVariable, type=bool):
     """Whether to enable shared object store or not."""
 
-    default = False
+    default = True
     varname = "UNIDIST_MPI_SHARED_OBJECT_STORE"
 
 


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #386  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
