### PR TITLE
FEAT-#392: Raise a warning if shared object storage is enabled but the MPI library does not support it

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -200,14 +200,15 @@ to start the number of workers exceeding the number of physical cores.
 
 To get more information about the flags refer to `Open MPI's mpiexec`_ command documentation.
 
-.. _`Open MPI's mpiexec`: https://www.open-mpi.org/doc/v3.1/man1/mpiexec.1.php
-.. _`issue`: https://github.com/modin-project/unidist/issues
+Shared object store for MPI backend is not supported in C/W model for MPICH version less than 4.2.0
+---------------------------------------------------------------------------------------------------
 
-
-Shared object store is not supported in C/W model if the using MPICH version is less than the 4.2.0 version.
-------------------------------------------------------------------------------------------------------------
-Unfortunately, this version of MPICH has a problem with shared memory in the Controller/Worker model.
+MPICH versions less than 4.2.0 have an issue related to shared memory feature in Controller/Worker model.
 
 **Solution**
-You can run your script using the SPMD model, or use other MPI implementations 
-such as Open MPI, Intel MPI, or MPICH above version 4.2.0.
+
+You can run your script using MPICH in SPMD model, or use other MPI implementations 
+such as Open MPI, Intel MPI, or MPICH above 4.2.0.
+
+.. _`Open MPI's mpiexec`: https://www.open-mpi.org/doc/v3.1/man1/mpiexec.1.php
+.. _`issue`: https://github.com/modin-project/unidist/issues

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -202,3 +202,12 @@ To get more information about the flags refer to `Open MPI's mpiexec`_ command d
 
 .. _`Open MPI's mpiexec`: https://www.open-mpi.org/doc/v3.1/man1/mpiexec.1.php
 .. _`issue`: https://github.com/modin-project/unidist/issues
+
+
+Shared object store is not supported in C/W model if the using MPICH version is less than the 4.2.0 version.
+------------------------------------------------------------------------------------------------------------
+Unfortunately, this version of MPICH has a problem with shared memory in the Controller/Worker model.
+
+**Solution**
+You can run your script using the SPMD model, or use other MPI implementations 
+such as Open MPI, Intel MPI, or MPICH above version 4.2.0.

--- a/unidist/core/backends/mpi/core/common.py
+++ b/unidist/core/backends/mpi/core/common.py
@@ -6,6 +6,7 @@
 
 import logging
 import inspect
+import warnings
 import weakref
 
 from unidist.config.backends.mpi.envvars import MpiSpawn
@@ -463,9 +464,14 @@ def check_mpich_version(target_version):
     return versiontuple(mpich_version) >= versiontuple(target_version)
 
 
-def is_shared_memory_supported():
+def is_shared_memory_supported(send_warning=False):
     """
     Check if the unidist on MPI supports shared memory.
+
+    Parameters
+    ----------
+    send_warning: bool, default: False
+        The need for warning as a flag.
 
     Returns
     -------
@@ -480,6 +486,9 @@ def is_shared_memory_supported():
         return False
 
     if MPI.VERSION < 3:
+        warnings.warn(
+            "The too old version of MPI is used. Shared object store can not be used."
+        )
         return False
 
     # Mpich shared memory does not work with spawned processes prior to version 4.2.0.
@@ -488,6 +497,10 @@ def is_shared_memory_supported():
         and MpiSpawn.get()
         and not check_mpich_version("4.2.0")
     ):
+        warnings.warn(
+            "Shared object store is not supported in C/W model if the using MPICH version is less than the 4.2.0 version."
+            + "Please read more about this problem in the `Troubleshooting` chapter of the Unidist documentation."
+        )
         return False
 
     return True

--- a/unidist/core/backends/mpi/core/shared_object_store.py
+++ b/unidist/core/backends/mpi/core/shared_object_store.py
@@ -107,9 +107,8 @@ class SharedObjectStore:
         self.service_info_max_count = None
 
         mpi_state = communication.MPIState.get_instance()
-
         # Initialize all properties above
-        if common.is_shared_memory_supported(send_warning=mpi_state.is_root_process()):
+        if common.is_shared_memory_supported(raise_warning=mpi_state.is_root_process()):
             self._allocate_shared_memory()
 
         # Logger will be initialized after `communicator.MPIState`

--- a/unidist/core/backends/mpi/core/shared_object_store.py
+++ b/unidist/core/backends/mpi/core/shared_object_store.py
@@ -106,8 +106,10 @@ class SharedObjectStore:
         # Length of service shared memory buffer in items
         self.service_info_max_count = None
 
+        mpi_state = communication.MPIState.get_instance()
+
         # Initialize all properties above
-        if common.is_shared_memory_supported():
+        if common.is_shared_memory_supported(send_warning=mpi_state.is_root_process()):
             self._allocate_shared_memory()
 
         # Logger will be initialized after `communicator.MPIState`


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #392  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
