### PR TITLE
FIX-#396: Fix Split_type call for Unidist on MSMPI

### DIFF
--- a/unidist/core/backends/mpi/core/communication.py
+++ b/unidist/core/backends/mpi/core/communication.py
@@ -118,7 +118,12 @@ class MPIState:
         self.global_rank = comm.Get_rank()
         self.global_size = comm.Get_size()
         self.host = socket.gethostbyname(socket.gethostname())
-        self.host_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
+        try:
+            self.host_comm = self.global_comm.Split_type(MPI.COMM_TYPE_SHARED)
+        # Used if Split_type does not work correctly in the MS MPI library
+        except MPI.Exception:
+            all_hosts = self.global_comm.allgather(self.host)
+            self.host_comm = self.global_comm.Split(all_hosts.index(self.host))
 
         host_rank = self.host_comm.Get_rank()
         # Get topology of MPI cluster.


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #396 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
