### PR TITLE
FIX-#404: Add psutil as a required dependency for unidist[mpi]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ class UnidistDistribution(Distribution):
 # https://github.com/modin-project/unidist/issues/324
 ray_deps = ["ray[default]>=1.13.0", "pydantic<2"]
 dask_deps = ["dask[complete]>=2.22.0", "distributed>=2.22.0"]
-mpi_deps = ["mpi4py>=3.0.3", "msgpack>=1.0.0"]
+mpi_deps = ["mpi4py>=3.0.3", "msgpack>=1.0.0", "psutil"]
 if sys.version_info[1] < 8:
     mpi_deps += "pickle5"
 all_deps = ray_deps + dask_deps + mpi_deps


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #404  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
