### PR TITLE
REFACTOR-#000: Format code to be in line with latest black

### DIFF
--- a/unidist/core/backends/mpi/core/monitor/shared_memory_manager.py
+++ b/unidist/core/backends/mpi/core/monitor/shared_memory_manager.py
@@ -208,13 +208,15 @@ class SharedMemoryManager:
         has_refs = array(
             "B",
             [
-                1
-                if data_id in self._reservation_info
-                and self.shared_store.get_ref_number(
-                    data_id, self._reservation_info[data_id]["service_index"]
+                (
+                    1
+                    if data_id in self._reservation_info
+                    and self.shared_store.get_ref_number(
+                        data_id, self._reservation_info[data_id]["service_index"]
+                    )
+                    > 0
+                    else 0
                 )
-                > 0
-                else 0
                 for data_id in cleanup_list
             ],
         )

--- a/unidist/core/backends/mpi/core/shared_object_store.py
+++ b/unidist/core/backends/mpi/core/shared_object_store.py
@@ -230,9 +230,11 @@ class SharedObjectStore:
         info = MPI.Info.Create()
         info.Set("alloc_shared_noncontig", "true")
         self.win = MPI.Win.Allocate_shared(
-            self.shared_memory_size * MPI.BYTE.size
-            if mpi_state.is_monitor_process()
-            else 0,
+            (
+                self.shared_memory_size * MPI.BYTE.size
+                if mpi_state.is_monitor_process()
+                else 0
+            ),
             MPI.BYTE.size,
             comm=mpi_state.host_comm,
             info=info,
@@ -245,9 +247,11 @@ class SharedObjectStore:
             * self.INFO_SIZE
         )
         self.service_win = MPI.Win.Allocate_shared(
-            self.service_info_max_count * MPI.LONG.size
-            if mpi_state.is_monitor_process()
-            else 0,
+            (
+                self.service_info_max_count * MPI.LONG.size
+                if mpi_state.is_monitor_process()
+                else 0
+            ),
             MPI.LONG.size,
             comm=mpi_state.host_comm,
             info=info,
@@ -363,13 +367,13 @@ class SharedObjectStore:
         worker_id, data_number = self._parse_data_id(data_id)
 
         with WinLock(self.service_win):
-            self.service_shared_buffer[
-                service_index + self.FIRST_DATA_INDEX
-            ] = first_index
+            self.service_shared_buffer[service_index + self.FIRST_DATA_INDEX] = (
+                first_index
+            )
             self.service_shared_buffer[service_index + self.REFERENCES_NUMBER] = 1
-            self.service_shared_buffer[
-                service_index + self.DATA_NUMBER_INDEX
-            ] = data_number
+            self.service_shared_buffer[service_index + self.DATA_NUMBER_INDEX] = (
+                data_number
+            )
             self.service_shared_buffer[service_index + self.WORKER_ID_INDEX] = worker_id
 
         self.finalizers.append(


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
