### PR TITLE
FIX-#416: Modify setup.py to enable python and platforms specific builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,8 @@
 import pathlib
 from setuptools import setup, find_packages, Extension
-from setuptools.dist import Distribution
 from Cython.Build import cythonize
 import sys
 import versioneer
-
-
-try:
-    from wheel.bdist_wheel import bdist_wheel
-
-    HAS_WHEEL = True
-except ImportError:
-    HAS_WHEEL = False
-
-if HAS_WHEEL:
-
-    class UnidistWheel(bdist_wheel):
-        def finalize_options(self):
-            bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
-
-        def get_tag(self):
-            _, _, plat = bdist_wheel.get_tag(self)
-            py = "py3"
-            abi = "none"
-            return py, abi, plat
-
-
-class UnidistDistribution(Distribution):
-    def __init__(self, *attrs):
-        Distribution.__init__(self, *attrs)
-        if HAS_WHEEL:
-            self.cmdclass["bdist_wheel"] = UnidistWheel
-
-    def is_pure(self):
-        return False
 
 
 # https://github.com/modin-project/unidist/issues/324
@@ -60,7 +28,6 @@ setup(
     name="unidist",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    distclass=UnidistDistribution,
     description="Unified Distributed Execution",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What do these changes do?

Resolves part of #416.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #416  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
