### PR TITLE
FIX-#425: Fix type of shared MPI.buffer

### DIFF
--- a/unidist/core/backends/mpi/core/shared_object_store.py
+++ b/unidist/core/backends/mpi/core/shared_object_store.py
@@ -445,13 +445,17 @@ class SharedObjectStore:
         first_index = self.service_shared_buffer[service_index + self.FIRST_DATA_INDEX]
 
         s_data_last_index = first_index + s_data_len
-        s_data = self.shared_buffer[first_index:s_data_last_index].toreadonly()
+        s_data = (
+            self.shared_buffer[first_index:s_data_last_index].cast("b").toreadonly()
+        )
         prev_last_index = s_data_last_index
         raw_buffers = []
         for raw_buffer_len in buffer_lens:
             raw_last_index = prev_last_index + raw_buffer_len
             raw_buffers.append(
-                self.shared_buffer[prev_last_index:raw_last_index].toreadonly()
+                self.shared_buffer[prev_last_index:raw_last_index]
+                .cast("b")
+                .toreadonly()
             )
             prev_last_index = raw_last_index
 


### PR DESCRIPTION
Mpi4py changed the default MPI.buffer type from signed char ('b') to unsigned char ('B'), which is the cause of incorrect data deserialization.

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://unidist.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 .`
- [x] passes `black .`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #425 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
